### PR TITLE
Feature/ease sirius use

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -41,8 +41,8 @@ using DatasetUPtr = std::unique_ptr<::GDALDataset, detail::DatasetDeleter>;
 Sirius multi-threaded streaming is based on [lambdas][lambda] and [task mechanism][std::async]:
 
 * One task will read an image block from the input image and feed an input queue
-* N worker tasks will consume the input queue, compute the zoom and feed an output queue
-* One task will consume the output queue and write the zoomed block into the output image.
+* N worker tasks will consume the input queue, compute the resampling and feed an output queue
+* One task will consume the output queue and write the resampled block into the output image.
 
 Tasks are created using [`std::async`][std::async] with the policy `std::launch::async` (force the creation of a new thread to execute the given task).
 
@@ -88,16 +88,16 @@ C++11 standard guarantees that a unique instance will be initialized and that th
 
 ### Factory
 
-The `FrequencyZoom` is the combination of two algorithms:
+The `FrequencyResampler` is the combination of two algorithms:
 * an image decomposition algorithm
 * a zoom algorithm
 
-Sirius provides an `IFrequencyZoom` factory to compose the zoom type requested by a client.
-API clients should only deal with `IFrequencyZoom` interface and should not be concerned by `IFrequencyZoom` implementations.
+Sirius provides an `IFrequencyResampler` factory to compose the resampler requested by a client.
+API clients should only deal with `IFrequencyResampler` interface and should not be concerned by `IFrequencyResampler` implementations.
 
 ### Policy/Strategy
 
-`FrequencyZoom` is the composition of an image decomposition algorithm and a zoom algorithm.
+`FrequencyResampler` is the composition of an image decomposition algorithm and a zoom algorithm.
 The policy/strategy pattern is used to adapt the internal behavior of this class.
 
 An algorithm implementation must comply with an an algorithm type implicit interface.
@@ -139,7 +139,7 @@ FFTW plans are cached so that a plan with a given size is reused if it has alrea
 
 ### Concurrent queue
 
-Sirius multi-threaded streaming is using `ConcurrentQueue` instances to feed zoom workers and to feed output stream.
+Sirius multi-threaded streaming is using `ConcurrentQueue` instances to feed resampler workers and to feed output stream.
 
 This queue implementation is based on [std::condition_variable].
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,10 @@ Usage:
  filter options:
       --filter arg           Path to the filter image to apply to the source
                              or resampled image
-      --filter-no-padding    Do not add filter margins on input borders
-                             (default is mirror padding)
-      --filter-zero-padding  Use zero padding strategy to add filter margins
-                             on input borders (default is mirror padding)
       --filter-normalize     Normalize filter coefficients (default is no
                              normalization)
+      --zero-pad-real-edges  Force zero padding strategy on real input edges
+                             (default is mirror padding)
 
  streaming options:
       --stream                  Enable stream mode
@@ -211,28 +209,25 @@ Sirius can use two image decomposition algorithms:
 
 Sirius can use two upsampling strategies:
 * Periodization: default behavior if a filter is provided.
-* Zero padding: default algorithm if no filter is provided)
+* Zero padding: default algorithm if no filter is provided.
 
 
 Upsampling strategies can be forced with the following options:
 * `--upsampling-zero-padding`
 * `--upsampling-periodization`
 
-**Force periodization upsampling without providing a filter will result in an error.**
+*Force periodization upsampling without providing a filter will result in an error.*
 
 More details on algorithms in the [Theoretical Basis documentation][Theoretical Basis].
 
 #### Filter options
 
 A filter image path can be specified with the option `--filter`. This filter will be applied:
-* on the resampled image if the image is zoomed in
-* on the source image if the image is zoomed out
+* on the resampled image if the image is upsampled.
+* on the source image if the image is downsampled.
 
-Default behavior will pad filter margins with a mirroring of the image borders.
-
-`--filter-no-padding` will change the padding strategy and will not pad filter margins on the image borders.
-
-`--filter-zero-padding` will change the padding strategy and zero pad filter margins on the image borders.
+Default behavior will pad real input edges with a mirroring of the edges.
+`--zero-pad-real-edges` will change this strategy and zero pad real input edges.
 
 It is assumed that the filter is already normalized. If not, the option `--filter-normalize` will normize it before any processing.
 
@@ -242,7 +237,7 @@ More details on filters in the [Theoretical Basis documentation][Theoretical Bas
 
 ##### Zoom in
 
-The following command line will zoom in `input/lena.jpg` by 2 using periodic plus smooth image decomposition and zero padding zoom.
+The following command line will zoom in `input/lena.jpg` by 2 using periodic plus smooth image decomposition and zero padding upsampling.
 
 ```sh
 ./sirius -z 2 -d 1 \
@@ -268,7 +263,7 @@ The following command line will zoom in `input/sentinel2_20m.tif` by 2 using str
 
 ##### Zoom out
 
-The following command line will zoom out `input/lena.jpg` by 1/2 using periodic plus smooth image decomposition and filter for zoom 1/2.
+The following command line will zoom out `input/lena.jpg` by 1/2 using periodic plus smooth image decomposition and filter for downsampling 1/2.
 
 ```sh
 ./sirius -z 1 -d 2 \
@@ -276,7 +271,7 @@ The following command line will zoom out `input/lena.jpg` by 1/2 using periodic 
          input/lena.jpg output/lena_z2.jpg
 ```
 
-The following command line will zoom out `input/disparity.png` by 1/2 using periodic plus smooth image decomposition and filter for zoom 1/2.
+The following command line will zoom out `input/disparity.png` by 1/2 using periodic plus smooth image decomposition and filter for downsampling 1/2.
 
 ```sh
 ./sirius -z 1 -d 2 \
@@ -284,7 +279,7 @@ The following command line will zoom out `input/disparity.png` by 1/2 using peri
          input/disparity.png output/disparity_z1_2.jpg
 ```
 
-The following command line will zoom out `input/sentinel2_10m.tif` by 1/2 using using stream mode and 8 workers, periodic plus smooth image decomposition and filter for zoom 1/2.
+The following command line will zoom out `input/sentinel2_10m.tif` by 1/2 using using stream mode and 8 workers, periodic plus smooth image decomposition and filter for downsampling 1/2.
 
 ```sh
 ./sirius --stream --parallel-workers=8 \

--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ Usage:
                                 1)
       --no-image-decomposition  Do not decompose the input image (default is
                                 periodic plus smooth image decomposition)
-      --zoom-zero-padding       Use zero padding zoom algorithm (default is
-                                periodization zoom algorithm)
+      --upsample-periodization  Force periodization as upsampling algorithm
+                                (default algorithm if a filter is provided). A
+                                filter is required to use this algorithm
+      --upsample-zero-padding   Force zero padding as upsampling algorithm
+                                (default algorithm if no filter is provided)
 
  filter options:
       --filter arg           Path to the filter image to apply to the source
@@ -206,9 +209,16 @@ Sirius can use two image decomposition algorithms:
 * Periodic plus Smooth (default behavior) is splitting the input image into a periodic part and a smooth image part.
 * None (`--no-image-decomposition`) is using raw image data without any processing.
 
-Sirius can use two zoom strategies:
-* Periodization (default behavior)
-* Zero padding (`--zoom-zero-padding`)
+Sirius can use two upsampling strategies:
+* Periodization: default behavior if a filter is provided.
+* Zero padding: default algorithm if no filter is provided)
+
+
+Upsampling strategies can be forced with the following options:
+* `--upsampling-zero-padding`
+* `--upsampling-periodization`
+
+**Force periodization upsampling without providing a filter will result in an error.**
 
 More details on algorithms in the [Theoretical Basis documentation][Theoretical Basis].
 
@@ -236,18 +246,18 @@ The following command line will zoom in `input/lena.jpg` by 2 using periodic plu
 
 ```sh
 ./sirius -z 2 -d 1 \
-         --zoom-zero-padding \
+         --upsample-zero-padding \
          input/lena.jpg output/lena_z2.jpg
 ```
 
-The following command line will zoom in `input/lena.jpg` by 2 using periodic plus smooth image decomposition, periodization zoom and filter for zoom 2.
+The following command line will zoom in `input/lena.jpg` by 2 using periodic plus smooth image decomposition, periodization upsampling and filter for upsampling 2.
 
 ```sh
 ./sirius -z 2 -d 1 \
          input/lena.jpg output/lena_z2.jpg
 ```
 
-The following command line will zoom in `input/sentinel2_20m.tif` by 2 using stream mode and 8 workers, periodic plus smooth image decomposition, periodization zoom and filter for zoom 2.
+The following command line will zoom in `input/sentinel2_20m.tif` by 2 using stream mode and 8 workers, periodic plus smooth image decomposition, periodization upsampling and filter for upsampling 2.
 
 ```sh
 ./sirius --stream --parallel-workers=8 \
@@ -262,7 +272,6 @@ The following command line will zoom out `input/lena.jpg` by 1/2 using periodic 
 
 ```sh
 ./sirius -z 1 -d 2 \
-         --zoom-zero-padding \
          --filter filters/ZOOM_1_2.tif \
          input/lena.jpg output/lena_z2.jpg
 ```

--- a/README.md
+++ b/README.md
@@ -157,13 +157,14 @@ Usage:
 
  streaming options:
       --stream                  Enable stream mode
-      --block-width arg         Width of a stream block (default: 256)
-      --block-height arg        Height of a stream block (default: 256)
+      --block-width arg         Initial width of a stream block (default:
+                                256)
+      --block-height arg        Initial height of a stream block (default:
+                                256)
       --no-block-resizing       Disable block resizing optimization
       --parallel-workers [=arg(=1)]
                                 Parallel workers used to compute resampling
                                 (8 max) (default: 1)
-
 ```
 
 #### Processing mode options
@@ -196,7 +197,7 @@ Stream mode can be run in mono-threaded context (`--parallel-workers=1`) or in m
 
 It is possible to customize block size with the options `--block-witdh=XXX` and `--block-height=YYY`.
 
-Default behavior tries to optimize block size so that the processed block (block size + filter margins) width and height are dyadic. You can disable this optimization with the option `--no-block-resizing`.
+Default behavior tries to optimize given block size so that the processed block (block size + filter margins) width and height are dyadic. You can disable this optimization with the option `--no-block-resizing`.
 
 When dealing with real zoom, block width and height are computed so that they comply with the zoom ratio.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,28 +41,28 @@ set(SIRIUS_SRC
     sirius/filter.h
     sirius/filter.cc
 
-    sirius/i_frequency_zoom.h
-    sirius/frequency_zoom_factory.h
-    sirius/frequency_zoom_factory.cc
+    sirius/i_frequency_resampler.h
+    sirius/frequency_resampler_factory.h
+    sirius/frequency_resampler_factory.cc
 
     sirius/image_streamer.h
     sirius/image_streamer.cc
 
-    # zoom
-    sirius/zoom/frequency_zoom.h
-    sirius/zoom/frequency_zoom.txx
+    # resampler
+    sirius/resampler/frequency_resampler.h
+    sirius/resampler/frequency_resampler.txx
 
-    # zoom strategies
-    sirius/zoom/zoom_strategy/periodization_strategy.h
-    sirius/zoom/zoom_strategy/periodization_strategy.cc
-    sirius/zoom/zoom_strategy/zero_padding_strategy.h
-    sirius/zoom/zoom_strategy/zero_padding_strategy.cc
+    # resampler zoom strategies
+    sirius/resampler/zoom_strategy/periodization_strategy.h
+    sirius/resampler/zoom_strategy/periodization_strategy.cc
+    sirius/resampler/zoom_strategy/zero_padding_strategy.h
+    sirius/resampler/zoom_strategy/zero_padding_strategy.cc
 
-    # image decomposition policies
-    sirius/zoom/image_decomposition/regular_policy.h
-    sirius/zoom/image_decomposition/regular_policy.txx
-    sirius/zoom/image_decomposition/periodic_smooth_policy.h
-    sirius/zoom/image_decomposition/periodic_smooth_policy.txx
+    # resampler image decomposition policies
+    sirius/resampler/image_decomposition/regular_policy.h
+    sirius/resampler/image_decomposition/regular_policy.txx
+    sirius/resampler/image_decomposition/periodic_smooth_policy.h
+    sirius/resampler/image_decomposition/periodic_smooth_policy.txx
 
     # fftw
     sirius/fftw/exception.h
@@ -81,8 +81,8 @@ set(SIRIUS_SRC
     sirius/gdal/stream_block.h
     sirius/gdal/input_stream.h
     sirius/gdal/input_stream.cc
-    sirius/gdal/output_zoomed_stream.h
-    sirius/gdal/output_zoomed_stream.cc
+    sirius/gdal/resampled_output_stream.h
+    sirius/gdal/resampled_output_stream.cc
     sirius/gdal/types.h
     sirius/gdal/wrapper.h
     sirius/gdal/wrapper.cc

--- a/src/main.cc
+++ b/src/main.cc
@@ -56,7 +56,7 @@ struct CliParameters {
     // resampling options
     int input_resolution = 1;
     int output_resolution = 1;
-    bool periodic_smooth_image_decomposition = false;
+    bool no_image_decomposition = false;
     bool zpd_zoom_strategy = false;
 
     // filter options
@@ -117,16 +117,16 @@ int main(int argc, const char* argv[]) {
             zoom_ratio.output_resolution());
 
         sirius::ImageDecompositionPolicies image_decomposition_policy =
-              sirius::ImageDecompositionPolicies::kRegular;
+              sirius::ImageDecompositionPolicies::kPeriodicSmooth;
         sirius::FrequencyZoomStrategies zoom_strategy =
               sirius::FrequencyZoomStrategies::kPeriodization;
 
-        if (params.periodic_smooth_image_decomposition) {
-            LOG("sirius", info, "image decomposition: periodic plus smooth");
+        if (params.no_image_decomposition) {
+            LOG("sirius", info, "image decomposition: none");
             image_decomposition_policy =
-                  sirius::ImageDecompositionPolicies::kPeriodicSmooth;
+                  sirius::ImageDecompositionPolicies::kRegular;
         } else {
-            LOG("sirius", info, "image decomposition: regular");
+            LOG("sirius", info, "image decomposition: periodic plus smooth");
         }
         if (params.zpd_zoom_strategy) {
             LOG("sirius", info, "zoom: zero padding");
@@ -263,17 +263,17 @@ CliParameters GetCliParameters(int argc, const char* argv[]) {
          cxxopts::value(params.input_resolution)->default_value("1"))
         ("d,output-resolution", "Denominator of the resampling ratio",
          cxxopts::value(params.output_resolution)->default_value("1"))
-        ("id-periodic-smooth",
-         "Use Periodic plus Smooth image decomposition "
-         "(default is regular image decomposition)",
-         cxxopts::value(params.periodic_smooth_image_decomposition))
+        ("no-image-decomposition",
+         "Do not decompose the input image "
+         "(default is periodic plus smooth image decomposition)",
+         cxxopts::value(params.no_image_decomposition))
         ("zoom-zero-padding", "Use zero padding zoom algorithm "
          "(default is periodization zoom algorithm)",
          cxxopts::value(params.zpd_zoom_strategy));
 
     options.add_options("filter")
         ("filter",
-         "Path to the filter image to apply to the resampled image",
+         "Path to the filter image to apply to the source or resampled image",
          cxxopts::value(params.filter_path))
         ("filter-no-padding",
          "Do not add filter margins on input borders "

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,8 +54,7 @@ struct CliParameters {
     std::string verbosity_level = "info";
 
     // resampling options
-    int input_resolution = 1;
-    int output_resolution = 1;
+    std::string resampling_ratio = "1:1";
     bool no_image_decomposition = false;
     bool upsample_periodization = false;
     bool upsample_zero_padding = false;
@@ -110,9 +109,8 @@ int main(int argc, const char* argv[]) {
     LOG("sirius", info, "Sirius {} - {}", sirius::kVersion, sirius::kGitCommit);
 
     try {
-        sirius::ZoomRatio zoom_ratio(params.input_resolution,
-                                     params.output_resolution);
-        LOG("sirius", info, "resampling ratio: {}/{}",
+        auto zoom_ratio = sirius::ZoomRatio::Create(params.resampling_ratio);
+        LOG("sirius", info, "resampling ratio: {}:{}",
             zoom_ratio.input_resolution(), zoom_ratio.output_resolution());
 
         // filter parameters
@@ -263,13 +261,12 @@ CliParameters GetCliParameters(int argc, const char* argv[]) {
          cxxopts::value(params.verbosity_level)->default_value("info"));
 
     options.add_options("resampling")
-        ("z,input-resolution", "Numerator of the resampling ratio",
-         cxxopts::value(params.input_resolution)->default_value("1"))
-        ("d,output-resolution", "Denominator of the resampling ratio",
-         cxxopts::value(params.output_resolution)->default_value("1"))
+        ("r,resampling-ratio", "Resampling ratio as input:output, "
+          "allowed format: I (equivalent to I:1), I:O",
+         cxxopts::value(params.resampling_ratio)->default_value("1:1"))
         ("no-image-decomposition",
          "Do not decompose the input image "
-         "(default is periodic plus smooth image decomposition)",
+         "(default: periodic plus smooth image decomposition)",
          cxxopts::value(params.no_image_decomposition))
         ("upsample-periodization",
           "Force periodization as upsampling algorithm "
@@ -291,7 +288,7 @@ CliParameters GetCliParameters(int argc, const char* argv[]) {
          cxxopts::value(params.filter_normalize))
         ("zero-pad-real-edges",
          "Force zero padding strategy on real input edges "
-         "(default is mirror padding)",
+         "(default: mirror padding)",
          cxxopts::value(params.zero_pad_real_edges));
 
     options.add_options("streaming")

--- a/src/main.cc
+++ b/src/main.cc
@@ -62,8 +62,7 @@ struct CliParameters {
 
     // filter options
     std::string filter_path;
-    bool filter_no_padding = false;
-    bool filter_zero_padding = false;
+    bool zero_pad_real_edges = false;
 
     // stream mode options
     bool stream_mode = false;
@@ -118,10 +117,7 @@ int main(int argc, const char* argv[]) {
 
         // filter parameters
         sirius::PaddingType padding_type = sirius::PaddingType::kMirrorPadding;
-        if (params.filter_no_padding) {
-            LOG("sirius", info, "filter: no border padding");
-            padding_type = sirius::PaddingType::kNone;
-        } else if (params.filter_zero_padding) {
+        if (params.zero_pad_real_edges) {
             LOG("sirius", info, "filter: border zero padding");
             padding_type = sirius::PaddingType::kZeroPadding;
         } else {
@@ -289,18 +285,14 @@ CliParameters GetCliParameters(int argc, const char* argv[]) {
         ("filter",
          "Path to the filter image to apply to the source or resampled image",
          cxxopts::value(params.filter_path))
-        ("filter-no-padding",
-         "Do not add filter margins on input borders "
-         "(default is mirror padding)",
-         cxxopts::value(params.filter_no_padding))
-        ("filter-zero-padding",
-         "Use zero padding strategy to add filter margins on input borders "
-         "(default is mirror padding)",
-         cxxopts::value(params.filter_zero_padding))
         ("filter-normalize",
          "Normalize filter coefficients "
          "(default is no normalization)",
-         cxxopts::value(params.filter_normalize));
+         cxxopts::value(params.filter_normalize))
+        ("zero-pad-real-edges",
+         "Force zero padding strategy on real input edges "
+         "(default is mirror padding)",
+         cxxopts::value(params.zero_pad_real_edges));
 
     options.add_options("streaming")
         ("stream", "Enable stream mode",

--- a/src/main.cc
+++ b/src/main.cc
@@ -222,12 +222,16 @@ void RunStreamMode(const sirius::IFrequencyResampler& frequency_resampler,
             stream_block_size = sirius::utils::GenerateDyadicSize(
                   stream_block_size, zoom_ratio.input_resolution(),
                   filter.padding_size());
+            LOG("sirius", warn, "stream block resized to dyadic size: {}x{}",
+                stream_block_size.row, stream_block_size.col);
         }
     } else {
         // real zoom needs specific block size (row and col should be multiple
         // of input resolution and output resolution)
         stream_block_size = sirius::utils::GenerateZoomCompliantSize(
               stream_block_size, zoom_ratio);
+        LOG("sirius", warn, "stream block resized to comply with zoom: {}x{}",
+            stream_block_size.row, stream_block_size.col);
     }
     sirius::ImageStreamer streamer(
           params.input_image_path, params.output_image_path, stream_block_size,
@@ -294,9 +298,9 @@ CliParameters GetCliParameters(int argc, const char* argv[]) {
     options.add_options("streaming")
         ("stream", "Enable stream mode",
          cxxopts::value(params.stream_mode))
-        ("block-width", "Width of a stream block",
+        ("block-width", "Initial width of a stream block",
          cxxopts::value(params.stream_block_width)->default_value("256"))
-        ("block-height", "Height of a stream block",
+        ("block-height", "Initial height of a stream block",
          cxxopts::value(params.stream_block_height)->default_value("256"))
         ("no-block-resizing",
          "Disable block resizing optimization",

--- a/src/sirius/filter.cc
+++ b/src/sirius/filter.cc
@@ -24,8 +24,8 @@
 #include <cstring>
 
 #include "sirius/exception.h"
-#include "sirius/frequency_zoom_factory.h"
-#include "sirius/i_frequency_zoom.h"
+#include "sirius/frequency_resampler_factory.h"
+#include "sirius/i_frequency_resampler.h"
 
 #include "sirius/fftw/exception.h"
 #include "sirius/fftw/fftw.h"
@@ -248,7 +248,7 @@ Image ZoomFilterImageToInputResolution(const Image& filter_image,
           ImageDecompositionPolicies::kRegular;
     FrequencyZoomStrategies zoom_strategy =
           FrequencyZoomStrategies::kZeroPadding;
-    auto frequency_zoom = FrequencyZoomFactory::Create(
+    auto frequency_resampler = FrequencyResamplerFactory::Create(
           image_decomposition_policy, zoom_strategy);
 
     ZoomRatio new_zoom_ratio(zoom_ratio.output_resolution(), 1);
@@ -257,8 +257,8 @@ Image ZoomFilterImageToInputResolution(const Image& filter_image,
     utils::IFFTShift2D(filter_image.data.data(), filter_image.size,
                        shifted_filter.data.data());
 
-    auto zoomed_filter = frequency_zoom->Compute(new_zoom_ratio, shifted_filter,
-                                                 {0, 0, 0, 0}, {});
+    auto zoomed_filter = frequency_resampler->Compute(
+          new_zoom_ratio, shifted_filter, {0, 0, 0, 0}, {});
 
     Image unshifted_zoomed_filter(zoomed_filter.size);
     utils::FFTShift2D(zoomed_filter.data.data(), zoomed_filter.size,

--- a/src/sirius/filter.cc
+++ b/src/sirius/filter.cc
@@ -233,10 +233,6 @@ Filter Filter::CreateRealZoomFilter(Image filter_image,
         padding_col = static_cast<int>(filter_image.size.col / 2. *
                                        (1. / zoom_ratio.input_resolution()));
     }
-    LOG("filter", info, "zoomed filter size: {}x{}", filter_image.size.row,
-        filter_image.size.col);
-    LOG("filter", info, "zoomed filter padding: {}x{}", padding_row,
-        padding_col);
     return {std::move(filter_image),
             {padding_row, padding_col},
             zoom_ratio,
@@ -253,7 +249,7 @@ Image ZoomFilterImageToInputResolution(const Image& filter_image,
     auto frequency_resampler = FrequencyResamplerFactory::Create(
           image_decomposition_policy, zoom_strategy);
 
-    ZoomRatio new_zoom_ratio(zoom_ratio.output_resolution(), 1);
+    auto new_zoom_ratio = ZoomRatio::Create(zoom_ratio.output_resolution(), 1);
 
     Image shifted_filter(filter_image.size);
     utils::IFFTShift2D(filter_image.data.data(), filter_image.size,

--- a/src/sirius/filter.cc
+++ b/src/sirius/filter.cc
@@ -165,7 +165,7 @@ fftw::ComplexUPtr Filter::CreateFilterFFT(const Size& image_size) const {
 Filter Filter::CreateZoomOutFilter(Image filter_image,
                                    const ZoomRatio& zoom_ratio,
                                    PaddingType padding_type) {
-    LOG("filter", info, "zoom out filter: use filter on source image");
+    LOG("filter", info, "filter: downsampling");
     int padding_row = (filter_image.size.row % 2 == 0)
                             ? (filter_image.size.row / 2)
                             : (filter_image.size.row - 1) / 2;
@@ -182,7 +182,7 @@ Filter Filter::CreateZoomOutFilter(Image filter_image,
 Filter Filter::CreateZoomInFilter(Image filter_image,
                                   const ZoomRatio& zoom_ratio,
                                   PaddingType padding_type) {
-    LOG("filter", info, "zoom in filter: use filter on zoomed image");
+    LOG("filter", info, "filter: upsampling");
     int padding_row = static_cast<int>(
           ((filter_image.size.row - 1) / 2) *
           (zoom_ratio.output_resolution() /
@@ -213,7 +213,9 @@ Filter Filter::CreateZoomInFilter(Image filter_image,
 Filter Filter::CreateRealZoomFilter(Image filter_image,
                                     const ZoomRatio& zoom_ratio,
                                     PaddingType padding_type) {
-    LOG("filter", info, "real zoom filter: zoom filter to input resolution");
+    LOG("filter", info,
+        "filter: float upsampling factor (upsample filter to input "
+        "resolution)");
     // zoom filter image to input resolution
     filter_image = ZoomFilterImageToInputResolution(filter_image, zoom_ratio);
 

--- a/src/sirius/frequency_resampler_factory.cc
+++ b/src/sirius/frequency_resampler_factory.cc
@@ -19,45 +19,49 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "sirius/frequency_zoom_factory.h"
+#include "sirius/frequency_resampler_factory.h"
 
 #include "sirius/utils/log.h"
 
-#include "sirius/zoom/frequency_zoom.h"
-#include "sirius/zoom/image_decomposition/periodic_smooth_policy.h"
-#include "sirius/zoom/image_decomposition/regular_policy.h"
-#include "sirius/zoom/zoom_strategy/periodization_strategy.h"
-#include "sirius/zoom/zoom_strategy/zero_padding_strategy.h"
+#include "sirius/resampler/frequency_resampler.h"
+#include "sirius/resampler/image_decomposition/periodic_smooth_policy.h"
+#include "sirius/resampler/image_decomposition/regular_policy.h"
+#include "sirius/resampler/zoom_strategy/periodization_strategy.h"
+#include "sirius/resampler/zoom_strategy/zero_padding_strategy.h"
 
 namespace sirius {
 
-IFrequencyZoom::UPtr FrequencyZoomFactory::Create(
+IFrequencyResampler::UPtr FrequencyResamplerFactory::Create(
       ImageDecompositionPolicies image_decomposition,
       FrequencyZoomStrategies zoom_strategy) {
-    using FrequencyZoomRegularZeroPadding =
-          zoom::FrequencyZoom<zoom::ImageDecompositionRegularPolicy,
-                              zoom::ZeroPaddingZoomStrategy>;
+    using FrequencyResamplerRegularZeroPadding = resampler::FrequencyResampler<
+          resampler::ImageDecompositionRegularPolicy,
+          resampler::ZeroPaddingZoomStrategy>;
 
-    using FrequencyZoomRegularPeriodization =
-          zoom::FrequencyZoom<zoom::ImageDecompositionRegularPolicy,
-                              zoom::PeriodizationZoomStrategy>;
+    using FrequencyResamplerRegularPeriodization =
+          resampler::FrequencyResampler<
+                resampler::ImageDecompositionRegularPolicy,
+                resampler::PeriodizationZoomStrategy>;
 
-    using FrequencyZoomPeriodicSmoothZeroPadding =
-          zoom::FrequencyZoom<zoom::ImageDecompositionPeriodicSmoothPolicy,
-                              zoom::ZeroPaddingZoomStrategy>;
+    using FrequencyResamplerPeriodicSmoothZeroPadding =
+          resampler::FrequencyResampler<
+                resampler::ImageDecompositionPeriodicSmoothPolicy,
+                resampler::ZeroPaddingZoomStrategy>;
 
-    using FrequencyZoomPeriodicSmoothPeriodization =
-          zoom::FrequencyZoom<zoom::ImageDecompositionPeriodicSmoothPolicy,
-                              zoom::PeriodizationZoomStrategy>;
+    using FrequencyResamplerPeriodicSmoothPeriodization =
+          resampler::FrequencyResampler<
+                resampler::ImageDecompositionPeriodicSmoothPolicy,
+                resampler::PeriodizationZoomStrategy>;
 
     switch (image_decomposition) {
         case ImageDecompositionPolicies::kRegular:
             switch (zoom_strategy) {
                 case FrequencyZoomStrategies::kZeroPadding:
-                    return std::make_unique<FrequencyZoomRegularZeroPadding>();
+                    return std::make_unique<
+                          FrequencyResamplerRegularZeroPadding>();
                 case FrequencyZoomStrategies::kPeriodization:
                     return std::make_unique<
-                          FrequencyZoomRegularPeriodization>();
+                          FrequencyResamplerRegularPeriodization>();
                 default:
                     break;
             }
@@ -66,10 +70,10 @@ IFrequencyZoom::UPtr FrequencyZoomFactory::Create(
             switch (zoom_strategy) {
                 case FrequencyZoomStrategies::kZeroPadding:
                     return std::make_unique<
-                          FrequencyZoomPeriodicSmoothZeroPadding>();
+                          FrequencyResamplerPeriodicSmoothZeroPadding>();
                 case FrequencyZoomStrategies::kPeriodization:
                     return std::make_unique<
-                          FrequencyZoomPeriodicSmoothPeriodization>();
+                          FrequencyResamplerPeriodicSmoothPeriodization>();
                 default:
                     break;
             }
@@ -78,7 +82,7 @@ IFrequencyZoom::UPtr FrequencyZoomFactory::Create(
             break;
     }
 
-    LOG("frequency_zoom_factory", warn,
+    LOG("frequency_resampler_factory", warn,
         "combination of image decomposition and zoom strategy not implemented");
     return nullptr;
 }

--- a/src/sirius/frequency_resampler_factory.h
+++ b/src/sirius/frequency_resampler_factory.h
@@ -19,10 +19,10 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_FREQUENCY_ZOOM_FACTORY_H_
-#define SIRIUS_FREQUENCY_ZOOM_FACTORY_H_
+#ifndef SIRIUS_FREQUENCY_RESAMPLER_FACTORY_H_
+#define SIRIUS_FREQUENCY_RESAMPLER_FACTORY_H_
 
-#include "sirius/i_frequency_zoom.h"
+#include "sirius/i_frequency_resampler.h"
 
 namespace sirius {
 
@@ -43,22 +43,23 @@ enum class FrequencyZoomStrategies {
 };
 
 /**
- * \brief Factory of IFrequencyZoom that composes an image decomposition policy
- *        and a zoom strategy
+ * \brief Factory of IFrequencyResampler that composes an image decomposition
+ *   policy and a zoom strategy
  */
-class FrequencyZoomFactory {
+class FrequencyResamplerFactory {
   public:
     /**
-     * \brief IFrequencyZoom factory
+     * \brief IFrequencyResampler factory
      * \param image_decomposition cf. ImageDecompositionPolicies enum
      * \param zoom_strategy cf. FrequencyZoomStrategies enum
-     * \return requested composition of FrequencyZoom | nullptr if not available
+     * \return requested composition of FrequencyResampler | nullptr if not
+     * available
      */
-    static IFrequencyZoom::UPtr Create(
+    static IFrequencyResampler::UPtr Create(
           ImageDecompositionPolicies image_decomposition,
           FrequencyZoomStrategies zoom_strategy);
 };
 
 }  // namespace sirius
 
-#endif  // SIRIUS_FREQUENCY_ZOOM_FACTORY_H_
+#endif  // SIRIUS_FREQUENCY_RESAMPLER_FACTORY_H_

--- a/src/sirius/gdal/input_stream.cc
+++ b/src/sirius/gdal/input_stream.cc
@@ -48,7 +48,7 @@ InputStream::InputStream(const std::string& image_path,
         throw SiriusException("invalid block size");
     }
 
-    LOG("input_stream", info, "input image \"{}\", size: {}x{}", image_path,
+    LOG("input_stream", info, "input image '{}' ({}x{})", image_path,
         input_dataset_->GetRasterYSize(), input_dataset_->GetRasterXSize());
 }
 

--- a/src/sirius/gdal/input_stream.h
+++ b/src/sirius/gdal/input_stream.h
@@ -22,7 +22,6 @@
 #ifndef SIRIUS_GDAL_INPUT_STREAM_H_
 #define SIRIUS_GDAL_INPUT_STREAM_H_
 
-#include <mutex>
 #include <system_error>
 
 #include "sirius/image.h"

--- a/src/sirius/gdal/resampled_output_stream.cc
+++ b/src/sirius/gdal/resampled_output_stream.cc
@@ -43,7 +43,7 @@ ResampledOutputStream::ResampledOutputStream(const std::string& input_path,
     auto geo_ref = gdal::ComputeResampledGeoReference(input_path, zoom_ratio);
     output_dataset_ =
           gdal::CreateDataset(output_path, output_w, output_h, 1, geo_ref);
-    LOG("resampled_output_stream", info, "output image \"{}\", size: {}x{}",
+    LOG("resampled_output_stream", info, "resampled image '{}' ({}x{})",
         output_path, output_h, output_w);
 }
 
@@ -55,8 +55,10 @@ void ResampledOutputStream::Write(StreamBlock&& block, std::error_code& ec) {
           std::floor(block.col_idx * zoom_ratio_.input_resolution() /
                      static_cast<double>(zoom_ratio_.output_resolution()));
 
-    LOG("resampled_output_stream", debug, "writing {}x{} at {}x{}",
-        block.buffer.size.row, block.buffer.size.col, out_row_idx, out_col_idx);
+    LOG("resampled_output_stream", debug,
+        "writing block ({},{}) to ({},{}) (size: {}x{})", block.row_idx,
+        block.col_idx, out_row_idx, out_col_idx, block.buffer.size.row,
+        block.buffer.size.col);
 
     CPLErr err = output_dataset_->GetRasterBand(1)->RasterIO(
           GF_Write, out_col_idx, out_row_idx, block.buffer.size.col,

--- a/src/sirius/gdal/resampled_output_stream.cc
+++ b/src/sirius/gdal/resampled_output_stream.cc
@@ -19,7 +19,7 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "sirius/gdal/output_zoomed_stream.h"
+#include "sirius/gdal/resampled_output_stream.h"
 
 #include "sirius/gdal/error_code.h"
 #include "sirius/gdal/wrapper.h"
@@ -29,9 +29,9 @@
 namespace sirius {
 namespace gdal {
 
-OutputZoomedStream::OutputZoomedStream(const std::string& input_path,
-                                       const std::string& output_path,
-                                       const ZoomRatio& zoom_ratio)
+ResampledOutputStream::ResampledOutputStream(const std::string& input_path,
+                                             const std::string& output_path,
+                                             const ZoomRatio& zoom_ratio)
     : zoom_ratio_(zoom_ratio) {
     auto input_dataset = gdal::LoadDataset(input_path);
 
@@ -40,14 +40,14 @@ OutputZoomedStream::OutputZoomedStream(const std::string& input_path,
     int output_w =
           std::ceil(input_dataset->GetRasterXSize() * zoom_ratio_.ratio());
 
-    auto geo_ref = gdal::ComputeZoomedGeoReference(input_path, zoom_ratio);
+    auto geo_ref = gdal::ComputeResampledGeoReference(input_path, zoom_ratio);
     output_dataset_ =
           gdal::CreateDataset(output_path, output_w, output_h, 1, geo_ref);
-    LOG("output_stream", info, "output image \"{}\", size: {}x{}", output_path,
-        output_h, output_w);
+    LOG("resampled_output_stream", info, "output image \"{}\", size: {}x{}",
+        output_path, output_h, output_w);
 }
 
-void OutputZoomedStream::Write(StreamBlock&& block, std::error_code& ec) {
+void ResampledOutputStream::Write(StreamBlock&& block, std::error_code& ec) {
     int out_row_idx =
           std::floor(block.row_idx * zoom_ratio_.input_resolution() /
                      static_cast<double>(zoom_ratio_.output_resolution()));
@@ -55,8 +55,8 @@ void OutputZoomedStream::Write(StreamBlock&& block, std::error_code& ec) {
           std::floor(block.col_idx * zoom_ratio_.input_resolution() /
                      static_cast<double>(zoom_ratio_.output_resolution()));
 
-    LOG("output_stream", debug, "writing {}x{} at {}x{}", block.buffer.size.row,
-        block.buffer.size.col, out_row_idx, out_col_idx);
+    LOG("resampled_output_stream", debug, "writing {}x{} at {}x{}",
+        block.buffer.size.row, block.buffer.size.col, out_row_idx, out_col_idx);
 
     CPLErr err = output_dataset_->GetRasterBand(1)->RasterIO(
           GF_Write, out_col_idx, out_row_idx, block.buffer.size.col,
@@ -64,7 +64,7 @@ void OutputZoomedStream::Write(StreamBlock&& block, std::error_code& ec) {
           block.buffer.size.col, block.buffer.size.row, GDT_Float64, 0, 0,
           NULL);
     if (err) {
-        LOG("output_zoomed_stream", error,
+        LOG("resampled_output_stream", error,
             "GDAL error: {} - could not write to the given dataset", err);
         ec = make_error_code(err);
         return;

--- a/src/sirius/gdal/resampled_output_stream.h
+++ b/src/sirius/gdal/resampled_output_stream.h
@@ -19,11 +19,9 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_GDAL_OUTPUT_ZOOMED_STREAM_H_
-#define SIRIUS_GDAL_OUTPUT_ZOOMED_STREAM_H_
+#ifndef SIRIUS_GDAL_RESAMPLED_OUTPUT_STREAM_H_
+#define SIRIUS_GDAL_RESAMPLED_OUTPUT_STREAM_H_
 
-#include <mutex>
-#include <stack>
 #include <system_error>
 
 #include "sirius/types.h"
@@ -35,19 +33,19 @@ namespace sirius {
 namespace gdal {
 
 /**
- * \brief Write a zoomed image by block
+ * \brief Write a resampled image by block
  */
-class OutputZoomedStream {
+class ResampledOutputStream {
   public:
-    OutputZoomedStream(const std::string& input_path,
-                       const std::string& output_path,
-                       const ZoomRatio& zoom_ratio);
+    ResampledOutputStream(const std::string& input_path,
+                          const std::string& output_path,
+                          const ZoomRatio& zoom_ratio);
 
-    ~OutputZoomedStream() = default;
-    OutputZoomedStream(const OutputZoomedStream&) = delete;
-    OutputZoomedStream& operator=(const OutputZoomedStream&) = delete;
-    OutputZoomedStream(OutputZoomedStream&&) = delete;
-    OutputZoomedStream& operator=(OutputZoomedStream&&) = delete;
+    ~ResampledOutputStream() = default;
+    ResampledOutputStream(const ResampledOutputStream&) = delete;
+    ResampledOutputStream& operator=(const ResampledOutputStream&) = delete;
+    ResampledOutputStream(ResampledOutputStream&&) = delete;
+    ResampledOutputStream& operator=(ResampledOutputStream&&) = delete;
 
     /**
      * \brief Write a zoomed block in the output file
@@ -64,4 +62,4 @@ class OutputZoomedStream {
 }  // namespace gdal
 }  // namespace sirius
 
-#endif  // SIRIUS_GDAL_OUTPUT_ZOOMED_STREAM_H_
+#endif  // SIRIUS_GDAL_RESAMPLED_OUTPUT_STREAM_H_

--- a/src/sirius/gdal/wrapper.cc
+++ b/src/sirius/gdal/wrapper.cc
@@ -51,7 +51,7 @@ DatasetUPtr LoadDataset(const std::string& filepath) {
     DatasetUPtr dataset(
           static_cast<GDALDataset*>(::GDALOpen(filepath.c_str(), GA_ReadOnly)));
     if (dataset == nullptr) {
-        LOG("gdal", error, "could not open the image file {}", filepath);
+        LOG("gdal", error, "could not open the image file '{}'", filepath);
         throw gdal::Exception();
     }
 
@@ -73,7 +73,7 @@ DatasetUPtr CreateDataset(const std::string& filepath, int w, int h,
     DatasetUPtr dataset(
           driver->Create(filepath.c_str(), w, h, n_bands, GDT_Float32, NULL));
     if (dataset == nullptr) {
-        LOG("gdal", error, "could not create the image file {}", filepath);
+        LOG("gdal", error, "could not create the image file '{}'", filepath);
         throw gdal::Exception();
     }
 
@@ -115,7 +115,7 @@ Image LoadImage(const std::string& filepath) {
           tmp_size.col, tmp_size.row, GDT_Float64, 0, 0);
     if (err) {
         LOG("gdal", error,
-            "GDAL error: {} - could not get image data from file {}", err,
+            "GDAL error: {} - could not get image data from file '{}'", err,
             filepath);
         throw gdal::Exception();
     }
@@ -137,8 +137,8 @@ void SaveImage(const Image& image, const std::string& output_filepath,
                          const_cast<double*>(image.data.data()), image.size.col,
                          image.size.row, GDT_Float64, 0, 0);
     if (err) {
-        LOG("image", error, "GDAL error: {} - could not write in file {}", err,
-            output_filepath);
+        LOG("image", error, "GDAL error: {} - could not write in file '{}'",
+            err, output_filepath);
         throw gdal::Exception();
     }
 }

--- a/src/sirius/gdal/wrapper.cc
+++ b/src/sirius/gdal/wrapper.cc
@@ -29,7 +29,7 @@ namespace sirius {
 namespace gdal {
 
 GeoReference::GeoReference()
-    : geo_transform{0, 1, 0, 0, 1, 0},
+    : geo_transform{0, 1, 0, 0, 0, 1},
       projection_ref(""),
       is_initialized(false) {}
 
@@ -143,16 +143,16 @@ void SaveImage(const Image& image, const std::string& output_filepath,
     }
 }
 
-GeoReference ComputeZoomedGeoReference(const std::string& input_path,
-                                       const ZoomRatio& zoom_ratio) {
+GeoReference ComputeResampledGeoReference(const std::string& input_path,
+                                          const ZoomRatio& zoom_ratio) {
     auto input_dataset = sirius::gdal::LoadDataset(input_path);
 
-    return {ComputeOutputGeoTransform(input_dataset.get(), zoom_ratio),
+    return {ComputeResampledGeoTransform(input_dataset.get(), zoom_ratio),
             input_dataset->GetProjectionRef()};
 }
 
-std::vector<double> ComputeOutputGeoTransform(GDALDataset* dataset,
-                                              const ZoomRatio& zoom_ratio) {
+std::vector<double> ComputeResampledGeoTransform(GDALDataset* dataset,
+                                                 const ZoomRatio& zoom_ratio) {
     std::vector<double> geo_transform(6);
     CPLErr err = dataset->GetGeoTransform(geo_transform.data());
     if (err) {

--- a/src/sirius/gdal/wrapper.h
+++ b/src/sirius/gdal/wrapper.h
@@ -60,12 +60,12 @@ DatasetUPtr CreateDataset(const std::string& filepath, int w, int h,
                           int n_bands, const GeoReference& geo_ref = {});
 
 /**
- * \brief Compute zoomed georeference information
+ * \brief Compute resampled georeference information
  * \param input_path input image path
  * \param zoom_ratio zoom ratio
  */
-GeoReference ComputeZoomedGeoReference(const std::string& input_path,
-                                       const ZoomRatio& zoom_ratio);
+GeoReference ComputeResampledGeoReference(const std::string& input_path,
+                                          const ZoomRatio& zoom_ratio);
 
 /**
  * \brief Compute output image origin and pixel size
@@ -73,8 +73,8 @@ GeoReference ComputeZoomedGeoReference(const std::string& input_path,
  * \param zoom_ratio zoom ratio to be applied
  * \return new geo transform
  */
-std::vector<double> ComputeOutputGeoTransform(GDALDataset* dataset,
-                                              const ZoomRatio& zoom_ratio);
+std::vector<double> ComputeResampledGeoTransform(GDALDataset* dataset,
+                                                 const ZoomRatio& zoom_ratio);
 
 }  // namespace gdal
 }  // namespace sirius

--- a/src/sirius/i_frequency_resampler.h
+++ b/src/sirius/i_frequency_resampler.h
@@ -19,8 +19,8 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_I_FREQUENCY_ZOOM_H_
-#define SIRIUS_I_FREQUENCY_ZOOM_H_
+#ifndef SIRIUS_I_FREQUENCY_RESAMPLER_H_
+#define SIRIUS_I_FREQUENCY_RESAMPLER_H_
 
 #include <memory>
 #include <string>
@@ -33,18 +33,18 @@
 namespace sirius {
 
 /**
- * \class IFrequencyZoom
- * \brief Interface that frequency zoom should implement
+ * \class IFrequencyResampler
+ * \brief Interface that frequency resampler should implement
  */
-class IFrequencyZoom {
+class IFrequencyResampler {
   public:
-    using UPtr = std::unique_ptr<IFrequencyZoom>;
+    using UPtr = std::unique_ptr<IFrequencyResampler>;
 
   public:
-    virtual ~IFrequencyZoom() = default;
+    virtual ~IFrequencyResampler() = default;
 
     /**
-     * \brief Zoom in/out an image by a zoom ratio
+     * \brief Resample an image by a ratio in the frequency domain
      *
      * \remark This method is thread safe
      *
@@ -65,4 +65,4 @@ class IFrequencyZoom {
 
 }  // namespace sirius
 
-#endif  // SIRIUS_I_FREQUENCY_ZOOM_H_
+#endif  // SIRIUS_I_FREQUENCY_RESAMPLER_H_

--- a/src/sirius/image.cc
+++ b/src/sirius/image.cc
@@ -61,8 +61,6 @@ Image Image::CreatePaddedImage(const Padding& padding) const {
             return CreateZeroPaddedImage(padding);
         case PaddingType::kMirrorPadding:
             return CreateMirrorPaddedImage(padding);
-        case PaddingType::kNone:
-            return {*this};
         default:
             LOG("image", warn, "padding type not handled, zero pad image");
             return CreateZeroPaddedImage(padding);

--- a/src/sirius/image.h
+++ b/src/sirius/image.h
@@ -31,7 +31,6 @@ namespace sirius {
 enum class PaddingType {
     kZeroPadding = 0,   /**<  zero padding: fill margins with 0*/
     kMirrorPadding = 1, /**<  mirror padding: duplicate rows/cols in mirror*/
-    kNone = 2           /**<  none: do not add data for margins*/
 };
 
 /**
@@ -54,8 +53,7 @@ struct Padding {
     int right{0};
 
     bool IsEmpty() const {
-        return type == PaddingType::kNone ||
-               (top == 0 && bottom == 0 && left == 0 && right == 0);
+        return (top == 0 && bottom == 0 && left == 0 && right == 0);
     }
 
     PaddingType type{PaddingType::kMirrorPadding};

--- a/src/sirius/image_streamer.h
+++ b/src/sirius/image_streamer.h
@@ -23,10 +23,10 @@
 #define SIRIUS_IMAGE_STREAMER_H_
 
 #include "sirius/filter.h"
-#include "sirius/i_frequency_zoom.h"
+#include "sirius/i_frequency_resampler.h"
 
 #include "sirius/gdal/input_stream.h"
-#include "sirius/gdal/output_zoomed_stream.h"
+#include "sirius/gdal/resampled_output_stream.h"
 #include "sirius/gdal/wrapper.h"
 
 namespace sirius {
@@ -38,7 +38,7 @@ class ImageStreamer {
   public:
     /**
      * \brief Instanciate an image streamer which will stream input image, apply
-     *        a zoom transformation and write into the output image
+     *   a resampling transformation and write the result into the output image
      * \param input_path input image path
      * \param output_path output image path
      * \param block_size stream block size
@@ -54,37 +54,41 @@ class ImageStreamer {
                   unsigned int max_parallel_workers);
 
     /**
-     * \brief Stream the input image, compute the zoom and stream output data
-     * \param frequency_zoom requested frequency zoom to apply on stream block
+     * \brief Stream the input image, compute the resampling and stream
+     *   output data
+     * \param frequency_resampler requested frequency resampler to apply on
+     *   stream block
      * \param filter filter to apply on the stream block
      */
-    void Stream(const IFrequencyZoom& frequency_zoom, const Filter& filter);
+    void Stream(const IFrequencyResampler& frequency_resampler,
+                const Filter& filter);
 
   private:
     /**
      * \brief Stream image in monothreading mode
      *
-     * Read a block, compute the zoom and write the output in the output file
+     * Read a block, compute the resample and write the output in the output
+     *   file
      *
-     * \param frequency_zoom frequency zoom to apply on stream block
+     * \param frequency_resampler frequency zoom to apply on stream block
      * \param filter filter to apply on stream block
      */
-    void RunMonothreadStream(const IFrequencyZoom& frequency_zoom,
+    void RunMonothreadStream(const IFrequencyResampler& frequency_resampler,
                              const Filter& filter);
 
     /**
      * \brief Stream image in multithreading mode
      *
      * One thread will generate input blocks and feed an input queue
-     * One thread will consume zoomed blocks from an output queue and write them
-     * in the output file
+     * One thread will consume resampled blocks from an output queue and write
+     *   them in the output file
      * max_parallel_tasks threads will consume input blocks from an input queue,
-     * compute the zoom and feed an output queue
+     *   compute the resampled blocks and feed an output queue
      *
-     * \param frequency_zoom frequency zoom to apply on stream block
+     * \param frequency_resampler frequency zoom to apply on stream block
      * \param filter filter to apply on stream block
      */
-    void RunMultithreadStream(const IFrequencyZoom& frequency_zoom,
+    void RunMultithreadStream(const IFrequencyResampler& frequency_resampler,
                               const Filter& filter);
 
   private:
@@ -92,7 +96,7 @@ class ImageStreamer {
     Size block_size_;
     ZoomRatio zoom_ratio_;
     gdal::InputStream input_stream_;
-    gdal::OutputZoomedStream output_stream_;
+    gdal::ResampledOutputStream output_stream_;
 };
 
 }  // namespace sirius

--- a/src/sirius/resampler/frequency_resampler.h
+++ b/src/sirius/resampler/frequency_resampler.h
@@ -19,36 +19,37 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_FREQUENCY_ZOOM_BASE_H_
-#define SIRIUS_ZOOM_FREQUENCY_ZOOM_BASE_H_
+#ifndef SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_H_
+#define SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_H_
 
-#include "sirius/i_frequency_zoom.h"
+#include "sirius/i_frequency_resampler.h"
 #include "sirius/image.h"
 
 #include "sirius/fftw/types.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 /**
- * \brief Implementation of IFrequencyZoom
+ * \brief Implementation of IFrequencyResampler
  */
 template <template <class> class ImageDecompositionPolicy, class ZoomStrategy>
-class FrequencyZoom final : public IFrequencyZoom,
-                            private ImageDecompositionPolicy<ZoomStrategy> {
+class FrequencyResampler final
+      : public IFrequencyResampler,
+        private ImageDecompositionPolicy<ZoomStrategy> {
   public:
-    FrequencyZoom() = default;
+    FrequencyResampler() = default;
 
     // copyable
-    FrequencyZoom(const FrequencyZoom&) = default;
-    FrequencyZoom& operator=(const FrequencyZoom&) = default;
+    FrequencyResampler(const FrequencyResampler&) = default;
+    FrequencyResampler& operator=(const FrequencyResampler&) = default;
     // moveable
-    FrequencyZoom(FrequencyZoom&&) = default;
-    FrequencyZoom& operator=(FrequencyZoom&&) = default;
+    FrequencyResampler(FrequencyResampler&&) = default;
+    FrequencyResampler& operator=(FrequencyResampler&&) = default;
 
-    ~FrequencyZoom() override = default;
+    ~FrequencyResampler() override = default;
 
-    // IFrequencyZoom interface
+    // IFrequencyResampler interface
     Image Compute(const ZoomRatio& ratio, const Image& input,
                   const Padding& image_padding,
                   const Filter& filter = {}) const override;
@@ -62,9 +63,9 @@ class FrequencyZoom final : public IFrequencyZoom,
                         const ZoomRatio& zoom_ratio) const;
 };
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#include "sirius/zoom/frequency_zoom.txx"
+#include "sirius/resampler/frequency_resampler.txx"
 
-#endif  // SIRIUS_FREQ_ZOOM_H_
+#endif  // SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_H_

--- a/src/sirius/resampler/frequency_resampler.txx
+++ b/src/sirius/resampler/frequency_resampler.txx
@@ -111,14 +111,6 @@ Image FrequencyResampler<ImageDecompositionPolicy, ZoomStrategy>::UnpadImage(
 
     int top_filter_margin = filter_padding_size.row;
     int left_filter_margin = filter_padding_size.col;
-    if (padding.type == PaddingType::kNone && padding.top != 0) {
-        // padding was ignored so there is no top padding
-        top_filter_margin = 0;
-    }
-    if (padding.type == PaddingType::kNone && padding.left != 0) {
-        // padding was ignored so there is no left padding
-        left_filter_margin = 0;
-    }
 
     int zoomed_col_length = input_size.col * zoom_ratio.input_resolution();
     int zoomed_left_padding_size =

--- a/src/sirius/resampler/frequency_resampler.txx
+++ b/src/sirius/resampler/frequency_resampler.txx
@@ -19,10 +19,10 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_FREQUENCY_ZOOM_TXX_
-#define SIRIUS_ZOOM_FREQUENCY_ZOOM_TXX_
+#ifndef SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_TXX_
+#define SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_TXX_
 
-#include "sirius/zoom/frequency_zoom.h"
+#include "sirius/resampler/frequency_resampler.h"
 
 #include <algorithm>
 
@@ -35,35 +35,35 @@
 #include "sirius/utils/log.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 template <template <class> class ImageDecompositionPolicy, class ZoomStrategy>
-Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::Compute(
+Image FrequencyResampler<ImageDecompositionPolicy, ZoomStrategy>::Compute(
       const ZoomRatio& zoom_ratio, const Image& input_image,
       const Padding& image_padding, const Filter& filter) const {
-    LOG("frequency_zoom", trace, "compute {}/{} zoom of the image",
+    LOG("frequency_resampler", trace, "compute {}/{} zoom of the image",
         zoom_ratio.input_resolution(), zoom_ratio.output_resolution());
 
     // basic checks
     if (filter.IsLoaded() && !filter.CanBeApplied(zoom_ratio)) {
-        LOG("frequency_zoom", error,
+        LOG("frequency_resampler", error,
             "cannot apply this filter on this zoom ratio");
         throw SiriusException("cannot apply this filter on this zoom ratio");
     }
 
-    LOG("frequency_zoom", trace, "pad image");
+    LOG("frequency_resampler", trace, "pad image");
     auto padded_image = input_image.CreatePaddedImage(image_padding);
 
     if (padded_image.size.col % 2 != 0 || padded_image.size.row % 2 != 0) {
         padded_image.CreateEvenImage();
     }
 
-    LOG("frequency_zoom", trace, "decompose and zoom image");
+    LOG("frequency_resampler", trace, "decompose and zoom image");
     // method inherited from ImageDecompositionPolicy
     Image result_image = this->DecomposeAndZoom(zoom_ratio.input_resolution(),
                                                 padded_image, filter);
 
-    LOG("frequency_zoom", trace, "unpad zoomed image");
+    LOG("frequency_resampler", trace, "unpad zoomed image");
     auto result = UnpadImage(zoom_ratio, input_image, result_image,
                              image_padding, filter);
 
@@ -75,7 +75,7 @@ Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::Compute(
 }
 
 template <template <class> class ImageDecompositionPolicy, class ZoomStrategy>
-Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::UnpadImage(
+Image FrequencyResampler<ImageDecompositionPolicy, ZoomStrategy>::UnpadImage(
       const ZoomRatio& zoom_ratio, const Image& original_image,
       const Image& zoomed_image, const Padding& padding,
       const Filter& filter) const {
@@ -145,9 +145,9 @@ Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::UnpadImage(
 }
 
 template <template <class> class ImageDecompositionPolicy, class ZoomStrategy>
-Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::DecimateImage(
+Image FrequencyResampler<ImageDecompositionPolicy, ZoomStrategy>::DecimateImage(
       const Image& zoomed_image, const ZoomRatio& zoom_ratio) const {
-    LOG("frequency_zoom", trace, "decimate zoomed image by {}",
+    LOG("frequency_resampler", trace, "decimate zoomed image by {}",
         zoom_ratio.output_resolution());
 
     Image decimated_image(
@@ -173,7 +173,7 @@ Image FrequencyZoom<ImageDecompositionPolicy, ZoomStrategy>::DecimateImage(
     return decimated_image;
 }
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#endif  // SIRIUS_ZOOM_FREQUENCY_ZOOM_TXX_
+#endif  // SIRIUS_RESAMPLER_FREQUENCY_RESAMPLER_TXX_

--- a/src/sirius/resampler/image_decomposition/periodic_smooth_policy.h
+++ b/src/sirius/resampler/image_decomposition/periodic_smooth_policy.h
@@ -19,28 +19,33 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_
-#define SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_
+#ifndef SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_
+#define SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_
 
 #include "sirius/filter.h"
 #include "sirius/image.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 /**
- * \brief Implementation of regular image decomposition
+ * \brief Implementation of <a
+ * href="https://hal.archives-ouvertes.fr/file/index/docid/388020/filename/2009-11.pdf">Periodic
+ * plus Smooth image decomposition</a>
  */
 template <class ZoomStrategy>
-class ImageDecompositionRegularPolicy : private ZoomStrategy {
+class ImageDecompositionPeriodicSmoothPolicy : private ZoomStrategy {
   public:
-    Image DecomposeAndZoom(int zoom, const Image& padded_image,
+    Image DecomposeAndZoom(int zoom, const Image& even_image,
                            const Filter& filter) const;
+
+  private:
+    Image Interpolate2D(int zoom, const Image& even_image) const;
 };
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#include "sirius/zoom/image_decomposition/regular_policy.txx"
+#include "sirius/resampler/image_decomposition/periodic_smooth_policy.txx"
 
-#endif  // SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_
+#endif  // SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_

--- a/src/sirius/resampler/image_decomposition/periodic_smooth_policy.txx
+++ b/src/sirius/resampler/image_decomposition/periodic_smooth_policy.txx
@@ -19,10 +19,10 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_
-#define SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_
+#ifndef SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_
+#define SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_
 
-#include "sirius/zoom/image_decomposition/periodic_smooth_policy.h"
+#include "sirius/resampler/image_decomposition/periodic_smooth_policy.h"
 
 #include "sirius/fftw/fftw.h"
 #include "sirius/fftw/types.h"
@@ -31,7 +31,7 @@
 #include "sirius/utils/gsl.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 template <class ZoomStrategy>
 Image ImageDecompositionPeriodicSmoothPolicy<ZoomStrategy>::DecomposeAndZoom(
@@ -247,7 +247,7 @@ Image ImageDecompositionPeriodicSmoothPolicy<ZoomStrategy>::Interpolate2D(
     return interpolated_im;
 }
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#endif  // SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_
+#endif  // SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_TXX_

--- a/src/sirius/resampler/image_decomposition/regular_policy.h
+++ b/src/sirius/resampler/image_decomposition/regular_policy.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 CS - Systeme d'Information (CS-SI)
+ * Copyright (C) 2018 CS - Systemes d'Information (CS-SI)
  *
  * This file is part of Sirius
  *
@@ -19,29 +19,28 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_
-#define SIRIUS_ZOOM_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_
+#ifndef SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_
+#define SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_
 
-#include "sirius/fftw/types.h"
 #include "sirius/filter.h"
 #include "sirius/image.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 /**
- * \brief Implementation of periodization frequency zoom
+ * \brief Implementation of regular image decomposition
  */
-class PeriodizationZoomStrategy {
+template <class ZoomStrategy>
+class ImageDecompositionRegularPolicy : private ZoomStrategy {
   public:
-    Image Zoom(int zoom, const Image& padded_image, const Filter& filter) const;
-
-  private:
-    fftw::ComplexUPtr PeriodizeFFT(int zoom, const Image& image,
-                                   fftw::ComplexUPtr image_fft) const;
+    Image DecomposeAndZoom(int zoom, const Image& padded_image,
+                           const Filter& filter) const;
 };
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#endif  // SIRIUS_ZOOM_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_
+#include "sirius/resampler/image_decomposition/regular_policy.txx"
+
+#endif  // SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_H_

--- a/src/sirius/resampler/image_decomposition/regular_policy.txx
+++ b/src/sirius/resampler/image_decomposition/regular_policy.txx
@@ -19,33 +19,23 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_
-#define SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_
+#ifndef SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_
+#define SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_
 
-#include "sirius/filter.h"
-#include "sirius/image.h"
+#include "sirius/resampler/image_decomposition/regular_policy.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
-/**
- * \brief Implementation of <a
- * href="https://hal.archives-ouvertes.fr/file/index/docid/388020/filename/2009-11.pdf">Periodic
- * plus Smooth image decomposition</a>
- */
 template <class ZoomStrategy>
-class ImageDecompositionPeriodicSmoothPolicy : private ZoomStrategy {
-  public:
-    Image DecomposeAndZoom(int zoom, const Image& even_image,
-                           const Filter& filter) const;
+Image ImageDecompositionRegularPolicy<ZoomStrategy>::DecomposeAndZoom(
+      int zoom, const Image& padded_image, const Filter& filter) const {
+    // method inherited from ZoomStrategy
+    LOG("regular_decomposition", trace, "zoom image");
+    return this->Zoom(zoom, padded_image, filter);
+}
 
-  private:
-    Image Interpolate2D(int zoom, const Image& even_image) const;
-};
-
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
-#include "sirius/zoom/image_decomposition/periodic_smooth_policy.txx"
-
-#endif  // SIRIUS_ZOOM_IMAGE_DECOMPOSITION_PERIODIC_SMOOTH_POLICY_H_
+#endif  // SIRIUS_RESAMPLER_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_

--- a/src/sirius/resampler/zoom_strategy/periodization_strategy.cc
+++ b/src/sirius/resampler/zoom_strategy/periodization_strategy.cc
@@ -19,7 +19,7 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "sirius/zoom/zoom_strategy/periodization_strategy.h"
+#include "sirius/resampler/zoom_strategy/periodization_strategy.h"
 
 #include <algorithm>
 
@@ -33,7 +33,7 @@
 #include "sirius/utils/log.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 Image PeriodizationZoomStrategy::Zoom(int zoom, const Image& padded_image,
                                       const Filter& filter) const {
@@ -181,5 +181,5 @@ fftw::ComplexUPtr PeriodizationZoomStrategy::PeriodizeFFT(
     return zoomed_fft;
 }
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius

--- a/src/sirius/resampler/zoom_strategy/periodization_strategy.h
+++ b/src/sirius/resampler/zoom_strategy/periodization_strategy.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 CS - Systemes d'Information (CS-SI)
+ * Copyright (C) 2018 CS - Systeme d'Information (CS-SI)
  *
  * This file is part of Sirius
  *
@@ -19,23 +19,29 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_
-#define SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_
+#ifndef SIRIUS_RESAMPLER_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_
+#define SIRIUS_RESAMPLER_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_
 
-#include "sirius/zoom/image_decomposition/regular_policy.h"
+#include "sirius/fftw/types.h"
+#include "sirius/filter.h"
+#include "sirius/image.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
-template <class ZoomStrategy>
-Image ImageDecompositionRegularPolicy<ZoomStrategy>::DecomposeAndZoom(
-      int zoom, const Image& padded_image, const Filter& filter) const {
-    // method inherited from ZoomStrategy
-    LOG("regular_decomposition", trace, "zoom image");
-    return this->Zoom(zoom, padded_image, filter);
-}
+/**
+ * \brief Implementation of periodization frequency zoom
+ */
+class PeriodizationZoomStrategy {
+  public:
+    Image Zoom(int zoom, const Image& padded_image, const Filter& filter) const;
 
-}  // namespace zoom
+  private:
+    fftw::ComplexUPtr PeriodizeFFT(int zoom, const Image& image,
+                                   fftw::ComplexUPtr image_fft) const;
+};
+
+}  // namespace resampler
 }  // namespace sirius
 
-#endif  // SIRIUS_ZOOM_IMAGE_DECOMPOSITION_REGULAR_POLICY_TXX_
+#endif  // SIRIUS_RESAMPLER_ZOOM_STRATEGY_PERIODIZATION_STRATEGY_H_

--- a/src/sirius/resampler/zoom_strategy/zero_padding_strategy.cc
+++ b/src/sirius/resampler/zoom_strategy/zero_padding_strategy.cc
@@ -19,7 +19,7 @@
  * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "sirius/zoom/zoom_strategy/zero_padding_strategy.h"
+#include "sirius/resampler/zoom_strategy/zero_padding_strategy.h"
 
 #include <algorithm>
 
@@ -35,7 +35,7 @@
 #include "sirius/utils/log.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 Image ZeroPaddingZoomStrategy::Zoom(int zoom, const Image& padded_image,
                                     const Filter& filter) const {
@@ -129,5 +129,5 @@ fftw::ComplexUPtr ZeroPaddingZoomStrategy::ZeroPadFFT(
     return zoomed_fft;
 }
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius

--- a/src/sirius/resampler/zoom_strategy/zero_padding_strategy.h
+++ b/src/sirius/resampler/zoom_strategy/zero_padding_strategy.h
@@ -28,7 +28,7 @@
 #include "sirius/fftw/types.h"
 
 namespace sirius {
-namespace zoom {
+namespace resampler {
 
 /**
  * \brief Implementation of zero padding frequency zoom
@@ -42,7 +42,7 @@ class ZeroPaddingZoomStrategy {
                                  fftw::ComplexUPtr image_fft) const;
 };
 
-}  // namespace zoom
+}  // namespace resampler
 }  // namespace sirius
 
 #endif  // SIRIUS_ZOOM_ZOOM_STRATEGY_ZERO_PADDING_STRATEGY_H_

--- a/src/sirius/types.cc
+++ b/src/sirius/types.cc
@@ -34,14 +34,46 @@ Size::Size(int row, int col) : row(row), col(col) {}
 
 Size::Size(const std::array<int, 2>& size) : row(size[0]), col(size[1]) {}
 
-ZoomRatio::ZoomRatio(int input_resolution, int output_resolution)
-    : input_resolution_(input_resolution),
-      output_resolution_(output_resolution) {
-    ReduceRatio();
+ZoomRatio ZoomRatio::Create(const std::string& ratio_string) {
+    auto delim_pos = ratio_string.find(':');
+
+    if (delim_pos == 0 || delim_pos == ratio_string.size() - 1) {
+        LOG("zoom_ratio", error, "invalid ratio string {}", ratio_string);
+        throw SiriusException("invalid ratio string");
+    }
+
+    int input_resolution = 1;
+    int output_resolution = 1;
+    try {
+        if (delim_pos == std::string::npos) {
+            // input resolution only
+            input_resolution = std::stoi(ratio_string);
+        } else {
+            input_resolution = std::stoi(ratio_string.substr(0, delim_pos));
+            output_resolution = std::stoi(ratio_string.substr(delim_pos + 1));
+        }
+    } catch (const std::exception& e) {
+        LOG("zoom_ratio", error, "invalid ratio string {} ({})", ratio_string,
+            e.what());
+        throw SiriusException("invalid ratio string");
+    }
+
+    return Create(input_resolution, output_resolution);
 }
 
+ZoomRatio ZoomRatio::Create(int input_resolution, int output_resolution) {
+    ZoomRatio ratio(input_resolution, output_resolution);
+    ratio.ReduceRatio();
+
+    return ratio;
+}
+
+ZoomRatio::ZoomRatio(int input_resolution, int output_resolution)
+    : input_resolution_(input_resolution),
+      output_resolution_(output_resolution) {}
+
 void ZoomRatio::ReduceRatio() {
-    if (input_resolution_ == 0 || output_resolution_ == 0) {
+    if (input_resolution_ <= 0 || output_resolution_ <= 0) {
         LOG("zoom_ratio", error, "invalid zoom ratio {}/{}", input_resolution_,
             output_resolution_);
         throw SiriusException("invalid zoom ratio");

--- a/src/sirius/types.h
+++ b/src/sirius/types.h
@@ -25,6 +25,7 @@
 #include <cmath>
 
 #include <array>
+#include <string>
 #include <vector>
 
 namespace sirius {
@@ -86,19 +87,32 @@ struct Size {
 class ZoomRatio {
   public:
     /**
-     * \brief Instantiate a zoom ratio 1/1
+     * \brief Create an instance from a formatted string
+     *        (input_resolution:output_resolution)
+     * \param ratio_string should be formatted as
+     *        "input_resolution:output_resolution"
+     * \return zoom ratio
+     *
+     * \throw SiriusException if string format or ratio is invalid
      */
-    ZoomRatio() = default;
+    static ZoomRatio Create(const std::string& ratio_string);
 
     /**
      * \brief Zoom ratio as input_resolution/output_resolution
      *        Reduce the ratio
      * \param input_resolution numerator of the ratio
      * \param output_resolution denominator of the ratio
+     * \return zoom ratio
      *
-     * \throw SiriusException if input or output resolution is invalid
+     * \throw SiriusException if ratio is invalid
+     * \throw std::invalid_argument if conversion from string to int failed
      */
-    ZoomRatio(int input_resolution, int output_resolution);
+    static ZoomRatio Create(int input_resolution, int output_resolution = 1);
+
+    /**
+     * \brief Instantiate a zoom ratio 1:1
+     */
+    ZoomRatio() = default;
 
     ~ZoomRatio() = default;
     ZoomRatio(const ZoomRatio&) = default;
@@ -117,6 +131,8 @@ class ZoomRatio {
     bool IsRealZoom() const;
 
   private:
+    ZoomRatio(int input_resolution, int output_resolution);
+
     void ReduceRatio();
 
   private:

--- a/src/sirius/utils/numeric.cc
+++ b/src/sirius/utils/numeric.cc
@@ -97,9 +97,6 @@ Size GenerateDyadicSize(const Size& size, const int res_in,
             return {initial_h, initial_w};
         }
     }
-    if (h != initial_h || w != initial_w) {
-        LOG("numeric", debug, "block resized to {}x{}", h, w);
-    }
 
     return {h, w};
 }
@@ -136,10 +133,6 @@ Size GenerateZoomCompliantSize(const Size& size, const ZoomRatio& zoom_r) {
                 zoom_r.ratio());
             return {initial_h, initial_w};
         }
-    }
-
-    if (h != initial_h || w != initial_w) {
-        LOG("numeric", debug, "block resized to {}x{}", h, w);
     }
 
     return {h, w};

--- a/tests/filter_tests.cc
+++ b/tests/filter_tests.cc
@@ -43,15 +43,20 @@ TEST_CASE("filter - empty filter", "[sirius]") {
 TEST_CASE("filter - dirac filter", "[sirius]") {
     LOG_SET_LEVEL(trace);
     sirius::Size size = {10, 10};
+    auto zoom_ratio = sirius::ZoomRatio::Create(1, 1);
     auto complex_array = sirius::fftw::CreateComplex(size);
     std::memset(complex_array.get(), 1, size.CellCount());
-    auto filter = sirius::Filter::Create("./filters/dirac_filter.tiff", {1, 1});
+
+    auto filter =
+          sirius::Filter::Create("./filters/dirac_filter.tiff", zoom_ratio);
     REQUIRE(filter.IsLoaded());
+
     auto output = filter.Process(size, std::move(complex_array));
 }
 
 TEST_CASE("filter - sinc2 filter", "[sirius]") {
     LOG_SET_LEVEL(trace);
+    auto zoom_ratio = sirius::ZoomRatio::Create(2, 1);
     sirius::Size regular_size = {100, 100};
     sirius::Size large_size = {1000, 1000};
 
@@ -59,8 +64,8 @@ TEST_CASE("filter - sinc2 filter", "[sirius]") {
         sirius::Size size{10, 10};
         auto complex_array = sirius::fftw::CreateComplex(size);
         std::memset(complex_array.get(), 1, size.CellCount());
-        auto filter =
-              sirius::Filter::Create("./filters/sinc_zoom2_filter.tif", {2, 1});
+        auto filter = sirius::Filter::Create("./filters/sinc_zoom2_filter.tif",
+                                             zoom_ratio);
         REQUIRE(filter.IsLoaded());
         REQUIRE_THROWS_AS(filter.Process(size, std::move(complex_array)),
                           sirius::SiriusException);
@@ -69,8 +74,8 @@ TEST_CASE("filter - sinc2 filter", "[sirius]") {
         sirius::Size size{100, 100};
         auto complex_array = sirius::fftw::CreateComplex(size);
         std::memset(complex_array.get(), 1, size.CellCount());
-        auto filter =
-              sirius::Filter::Create("./filters/sinc_zoom2_filter.tif", {2, 1});
+        auto filter = sirius::Filter::Create("./filters/sinc_zoom2_filter.tif",
+                                             zoom_ratio);
         REQUIRE(filter.IsLoaded());
         REQUIRE_NOTHROW(complex_array =
                               filter.Process(size, std::move(complex_array)));
@@ -80,16 +85,16 @@ TEST_CASE("filter - sinc2 filter", "[sirius]") {
         sirius::Size size{1000, 1000};
         auto complex_array = sirius::fftw::CreateComplex(size);
         std::memset(complex_array.get(), 1, size.CellCount());
-        auto filter =
-              sirius::Filter::Create("./filters/sinc_zoom2_filter.tif", {2, 1});
+        auto filter = sirius::Filter::Create("./filters/sinc_zoom2_filter.tif",
+                                             zoom_ratio);
         REQUIRE(filter.IsLoaded());
         REQUIRE_NOTHROW(complex_array =
                               filter.Process(size, std::move(complex_array)));
         REQUIRE_NOTHROW(filter.Process(size, std::move(complex_array)));
     }
     SECTION("sinc2 filter - image size is filter size") {
-        auto filter =
-              sirius::Filter::Create("./filters/sinc_zoom2_filter.tif", {2, 1});
+        auto filter = sirius::Filter::Create("./filters/sinc_zoom2_filter.tif",
+                                             zoom_ratio);
         auto size = filter.size();
         auto complex_array = sirius::fftw::CreateComplex(size);
         std::memset(complex_array.get(), 1, size.CellCount());

--- a/tests/frequency_resampler_tests.cc
+++ b/tests/frequency_resampler_tests.cc
@@ -64,7 +64,7 @@ TEST_CASE("frequency resampler - classic decomposition - zero padding zoom",
           "[sirius]") {
     LOG_SET_LEVEL(trace);
 
-    sirius::ZoomRatio zoom_ratio(2, 1);
+    auto zoom_ratio = sirius::ZoomRatio::Create(2, 1);
 
     // test inputs
     auto dummy_image = sirius::tests::CreateDummyImage({20, 20});
@@ -209,7 +209,7 @@ TEST_CASE("frequency resampler - classic decomposition - zero padding zoom",
 TEST_CASE("frequency resampler - classic - periodization zoom", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
-    sirius::ZoomRatio zoom_ratio(2, 1);
+    auto zoom_ratio = sirius::ZoomRatio::Create(2, 1);
 
     // test input
     auto dummy_image = sirius::tests::CreateDummyImage({4, 4});
@@ -362,7 +362,7 @@ TEST_CASE("frequency resampler - classic - periodization zoom", "[sirius]") {
 TEST_CASE("frequency resampler - periodic smooth - zero padding", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
-    sirius::ZoomRatio zoom_ratio(2, 1);
+    auto zoom_ratio = sirius::ZoomRatio::Create(2, 1);
 
     // test input
     auto dummy_image = sirius::tests::CreateDummyImage({256, 256});
@@ -421,7 +421,7 @@ TEST_CASE("frequency resampler - periodic smooth - zero padding", "[sirius]") {
 TEST_CASE("frequency resampler - real zoom", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
-    sirius::ZoomRatio zoom_ratio(7, 4);
+    auto zoom_ratio = sirius::ZoomRatio::Create(7, 4);
 
     // test input
     auto dummy_image = sirius::tests::CreateDummyImage({256, 256});
@@ -477,8 +477,8 @@ TEST_CASE("frequency resampler - real zoom", "[sirius]") {
 TEST_CASE("frequency resampler - example", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
-    sirius::ZoomRatio zoom_ratio_2_1(2, 1);
-    sirius::ZoomRatio zoom_ratio_7_4(7, 4);
+    auto zoom_ratio_2_1 = sirius::ZoomRatio::Create(2, 1);
+    auto zoom_ratio_7_4 = sirius::ZoomRatio::Create(7, 4);
 
     sirius::Image image = sirius::tests::CreateDummyImage({256, 256});
 

--- a/tests/frequency_resampler_tests.cc
+++ b/tests/frequency_resampler_tests.cc
@@ -27,7 +27,7 @@
 #include "sirius/filter.h"
 #include "sirius/image.h"
 
-#include "sirius/frequency_zoom_factory.h"
+#include "sirius/frequency_resampler_factory.h"
 
 #include "sirius/gdal/exception.h"
 #include "sirius/gdal/wrapper.h"
@@ -36,29 +36,31 @@
 
 #include "utils.h"
 
-TEST_CASE("frequency zoom - factory", "[sirius]") {
-    auto classic_zero_padding_zoom = sirius::FrequencyZoomFactory::Create(
-          sirius::ImageDecompositionPolicies::kRegular,
-          sirius::FrequencyZoomStrategies::kZeroPadding);
-    REQUIRE(classic_zero_padding_zoom != nullptr);
+TEST_CASE("frequency resampler - factory", "[sirius]") {
+    auto classic_zero_padding_resampler =
+          sirius::FrequencyResamplerFactory::Create(
+                sirius::ImageDecompositionPolicies::kRegular,
+                sirius::FrequencyZoomStrategies::kZeroPadding);
+    REQUIRE(classic_zero_padding_resampler != nullptr);
 
-    auto classic_periodization_zoom = sirius::FrequencyZoomFactory::Create(
-          sirius::ImageDecompositionPolicies::kRegular,
-          sirius::FrequencyZoomStrategies::kPeriodization);
-    REQUIRE(classic_periodization_zoom != nullptr);
+    auto classic_periodization_resampler =
+          sirius::FrequencyResamplerFactory::Create(
+                sirius::ImageDecompositionPolicies::kRegular,
+                sirius::FrequencyZoomStrategies::kPeriodization);
+    REQUIRE(classic_periodization_resampler != nullptr);
 
-    auto ps_zero_padding_zoom = sirius::FrequencyZoomFactory::Create(
+    auto ps_zero_padding_resampler = sirius::FrequencyResamplerFactory::Create(
           sirius::ImageDecompositionPolicies::kPeriodicSmooth,
           sirius::FrequencyZoomStrategies::kZeroPadding);
-    REQUIRE(ps_zero_padding_zoom != nullptr);
+    REQUIRE(ps_zero_padding_resampler != nullptr);
 
-    auto ps_periodization_zoom = sirius::FrequencyZoomFactory::Create(
+    auto ps_periodization_resampler = sirius::FrequencyResamplerFactory::Create(
           sirius::ImageDecompositionPolicies::kPeriodicSmooth,
           sirius::FrequencyZoomStrategies::kPeriodization);
-    REQUIRE(ps_periodization_zoom != nullptr);
+    REQUIRE(ps_periodization_resampler != nullptr);
 }
 
-TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
+TEST_CASE("frequency resampler - classic decomposition - zero padding zoom",
           "[sirius]") {
     LOG_SET_LEVEL(trace);
 
@@ -78,13 +80,13 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
     // output
     sirius::Image output;
 
-    auto freq_zoom = sirius::FrequencyZoomFactory::Create(
+    auto freq_resampler = sirius::FrequencyResamplerFactory::Create(
           sirius::ImageDecompositionPolicies::kRegular,
           sirius::FrequencyZoomStrategies::kZeroPadding);
 
     SECTION("dummy image - no filter") {
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, dummy_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, dummy_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -94,9 +96,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
     }
 
     SECTION("dummy image - dirac filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, dummy_image, dirac_filter.padding(),
+                              dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -106,9 +108,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
     }
 
     SECTION("dummy image - sinc filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, dummy_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -119,8 +121,8 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("Lena - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, lena_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, lena_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -133,9 +135,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("Lena - dirac filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(zoom_ratio, lena_image,
+                                                         dirac_filter.padding(),
+                                                         dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -148,9 +150,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("Lena - sinc filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, lena_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -163,8 +165,8 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("disp0 - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, disp0_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, disp0_image, {}));
         REQUIRE(output.data.size() > 0);
 
         LOG("tests", debug, "output size: {}, {}", output.size.row,
@@ -175,9 +177,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("disp0 - dirac") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, disp0_image, dirac_filter.padding(),
+                              dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (disp0_image.size * zoom_ratio.input_resolution()));
@@ -190,9 +192,9 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
 
     SECTION("disp0 - sinc") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, disp0_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (disp0_image.size * zoom_ratio.input_resolution()));
@@ -204,7 +206,7 @@ TEST_CASE("frequency zoom - classic decomposition - zero padding zoom",
     }
 }
 
-TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
+TEST_CASE("frequency resampler - classic - periodization zoom", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
     sirius::ZoomRatio zoom_ratio(2, 1);
@@ -223,13 +225,13 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
     // output
     sirius::Image output;
 
-    auto freq_zoom = sirius::FrequencyZoomFactory::Create(
+    auto freq_resampler = sirius::FrequencyResamplerFactory::Create(
           sirius::ImageDecompositionPolicies::kRegular,
           sirius::FrequencyZoomStrategies::kPeriodization);
 
     SECTION("dummy image - no filter") {
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, dummy_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, dummy_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -239,9 +241,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
     }
 
     SECTION("dummy image - dirac filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, dummy_image, dirac_filter.padding(),
+                              dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -251,9 +253,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
     }
 
     SECTION("dummy image - sinc filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, dummy_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (dummy_image.size * zoom_ratio.input_resolution()));
@@ -264,8 +266,8 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("Lena - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, lena_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, lena_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -279,9 +281,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("Lena - dirac filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(zoom_ratio, lena_image,
+                                                         dirac_filter.padding(),
+                                                         dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -295,9 +297,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("Lena - sinc filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, lena_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (lena_image.size * zoom_ratio.input_resolution()));
@@ -311,8 +313,8 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("disp0 - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, disp0_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, disp0_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (disp0_image.size * zoom_ratio.input_resolution()));
@@ -326,9 +328,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("disp0 - dirac") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, disp0_image, dirac_filter.padding(),
+                              dirac_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (disp0_image.size * zoom_ratio.input_resolution()));
@@ -342,9 +344,9 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
 
     SECTION("disp0 - sinc") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(output = freq_resampler->Compute(
+                              zoom_ratio, disp0_image,
+                              sinc_zoom2_filter.padding(), sinc_zoom2_filter));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size ==
                 (disp0_image.size * zoom_ratio.input_resolution()));
@@ -357,54 +359,85 @@ TEST_CASE("frequency zoom - classic - periodization zoom", "[sirius]") {
     }
 }
 
-TEST_CASE("frequency zoom - real zoom", "[sirius]") {
+TEST_CASE("frequency resampler - periodic smooth - zero padding", "[sirius]") {
+    LOG_SET_LEVEL(trace);
+
+    sirius::ZoomRatio zoom_ratio(2, 1);
+
+    // test input
+    auto dummy_image = sirius::tests::CreateDummyImage({256, 256});
+    auto lena_image = sirius::gdal::LoadImage("./input/lena.jpg");
+    auto disp0_image = sirius::gdal::LoadImage("./input/disparity.png");
+
+    // output
+    sirius::Image output;
+
+    auto freq_resampler = sirius::FrequencyResamplerFactory::Create(
+          sirius::ImageDecompositionPolicies::kPeriodicSmooth,
+          sirius::FrequencyZoomStrategies::kZeroPadding);
+
+    SECTION("dummy image - no filter") {
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, dummy_image, {}));
+        REQUIRE(output.data.size() > 0);
+        REQUIRE(output.size ==
+                (dummy_image.size * zoom_ratio.input_resolution()));
+
+        LOG("tests", debug, "output size: {}, {}", output.size.row,
+            output.size.col);
+    }
+
+    SECTION("Lena - no filter") {
+        sirius::Image output;
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, lena_image, {}));
+        REQUIRE(output.data.size() > 0);
+        REQUIRE(output.size ==
+                (lena_image.size * zoom_ratio.input_resolution()));
+
+        LOG("tests", debug, "output size: {}, {}", output.size.row,
+            output.size.col);
+
+        sirius::gdal::SaveImage(output,
+                                "./output/lena_periodic_smooth_no_filter.tif");
+    }
+
+    SECTION("disp0 - no filter") {
+        sirius::Image output;
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, disp0_image, {}));
+        REQUIRE(output.data.size() > 0);
+        REQUIRE(output.size ==
+                (disp0_image.size * zoom_ratio.input_resolution()));
+
+        LOG("tests", debug, "output size: {}, {}", output.size.row,
+            output.size.col);
+
+        sirius::gdal::SaveImage(
+              output, "./output/disparity_periodic_smooth_no_filter.tif");
+    }
+}
+
+TEST_CASE("frequency resampler - real zoom", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
     sirius::ZoomRatio zoom_ratio(7, 4);
 
     // test input
-    auto dummy_image = sirius::tests::CreateDummyImage({4, 4});
+    auto dummy_image = sirius::tests::CreateDummyImage({256, 256});
     auto lena_image = sirius::gdal::LoadImage("./input/lena.jpg");
     auto disp0_image = sirius::gdal::LoadImage("./input/disparity.png");
-
-    // filters
-    auto dirac_filter =
-          sirius::Filter::Create("./filters/dirac_filter.tiff", zoom_ratio);
-    auto sinc_zoom2_filter =
-          sirius::Filter::Create("./filters/sinc_zoom2_filter.tif", zoom_ratio);
 
     // output
     sirius::Image output;
 
-    auto freq_zoom = sirius::FrequencyZoomFactory::Create(
+    auto freq_resampler = sirius::FrequencyResamplerFactory::Create(
           sirius::ImageDecompositionPolicies::kRegular,
           sirius::FrequencyZoomStrategies::kZeroPadding);
 
     SECTION("dummy image - no filter") {
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, dummy_image, {}));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == dummy_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-    }
-
-    SECTION("dummy image - dirac filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == dummy_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-    }
-
-    SECTION("dummy image - sinc filter") {
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, dummy_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, dummy_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size == dummy_image.size * zoom_ratio.ratio());
 
@@ -414,8 +447,8 @@ TEST_CASE("frequency zoom - real zoom", "[sirius]") {
 
     SECTION("Lena - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, lena_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, lena_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size == lena_image.size * zoom_ratio.ratio());
 
@@ -426,40 +459,10 @@ TEST_CASE("frequency zoom - real zoom", "[sirius]") {
                                 "./output/lena_unzoom_7_4_no_filter.tif");
     }
 
-    SECTION("Lena - dirac filter") {
+    /*SECTION("disp0 - no filter") {
         sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == lena_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-
-        sirius::gdal::SaveImage(output,
-                                "./output/lena_unzoom_7_4_dirac_filter.tif");
-    }
-
-    SECTION("Lena - sinc filter") {
-        sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, lena_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == lena_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-
-        sirius::gdal::SaveImage(output,
-                                "./output/lena_unzoom_7_4_sinc_filter.tif");
-    }
-
-    SECTION("disp0 - no filter") {
-        sirius::Image output;
-        REQUIRE_NOTHROW(output =
-                              freq_zoom->Compute(zoom_ratio, disp0_image, {}));
+        REQUIRE_NOTHROW(
+              output = freq_resampler->Compute(zoom_ratio, disp0_image, {}));
         REQUIRE(output.data.size() > 0);
         REQUIRE(output.size == disp0_image.size * zoom_ratio.ratio());
 
@@ -468,40 +471,10 @@ TEST_CASE("frequency zoom - real zoom", "[sirius]") {
 
         sirius::gdal::SaveImage(output,
                                 "./output/disparity_unzoom_7_4_no_filter.tif");
-    }
-
-    SECTION("disp0 - dirac") {
-        sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    dirac_filter.padding(),
-                                                    dirac_filter));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == disp0_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-
-        sirius::gdal::SaveImage(
-              output, "./output/disparity_unzoom_7_4_dirac_filter.tif");
-    }
-
-    SECTION("disp0 - sinc") {
-        sirius::Image output;
-        REQUIRE_NOTHROW(output = freq_zoom->Compute(zoom_ratio, disp0_image,
-                                                    sinc_zoom2_filter.padding(),
-                                                    sinc_zoom2_filter));
-        REQUIRE(output.data.size() > 0);
-        REQUIRE(output.size == disp0_image.size * zoom_ratio.ratio());
-
-        LOG("tests", debug, "output size: {}, {}", output.size.row,
-            output.size.col);
-
-        sirius::gdal::SaveImage(
-              output, "./output/disparity_unzoom_7_4_sinc_filter.tif");
-    }
+    }*/
 }
 
-TEST_CASE("frequency zoom - example", "[sirius]") {
+TEST_CASE("frequency resampler - example", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
     sirius::ZoomRatio zoom_ratio_2_1(2, 1);
@@ -514,14 +487,14 @@ TEST_CASE("frequency zoom - example", "[sirius]") {
     auto sinc_filter = sirius::Filter::Create("./filters/sinc_zoom2_filter.tif",
                                               zoom_ratio_2_1);
 
-    sirius::IFrequencyZoom::UPtr freq_zoom =
-          sirius::FrequencyZoomFactory::Create(
+    sirius::IFrequencyResampler::UPtr freq_resampler =
+          sirius::FrequencyResamplerFactory::Create(
                 sirius::ImageDecompositionPolicies::kRegular,
                 sirius::FrequencyZoomStrategies::kZeroPadding);
 
-    sirius::Image zoomed_image_7_4 = freq_zoom->Compute(
+    sirius::Image zoomed_image_7_4 = freq_resampler->Compute(
           zoom_ratio_7_4, image, dirac_filter.padding(), dirac_filter);
 
-    sirius::Image zoomed_image_2_1 = freq_zoom->Compute(
+    sirius::Image zoomed_image_2_1 = freq_resampler->Compute(
           zoom_ratio_2_1, image, sinc_filter.padding(), sinc_filter);
 }

--- a/tests/functional_tests.cc
+++ b/tests/functional_tests.cc
@@ -26,7 +26,7 @@
 #include "sirius/filter.h"
 #include "sirius/image.h"
 
-#include "sirius/frequency_zoom_factory.h"
+#include "sirius/frequency_resampler_factory.h"
 
 #include "sirius/gdal/wrapper.h"
 
@@ -36,10 +36,10 @@ void GenerateZoomedImage(const std::string& output_filepath,
                          const sirius::Image& image,
                          const sirius::ZoomRatio& zoom_ratio,
                          const sirius::Filter& filter,
-                         const sirius::IFrequencyZoom& freq_zoom) {
+                         const sirius::IFrequencyResampler& freq_resampler) {
     LOG("functional_tests", debug, "* generating {}", output_filepath);
     auto output_image =
-          freq_zoom.Compute(zoom_ratio, image, filter.padding(), filter);
+          freq_resampler.Compute(zoom_ratio, image, filter.padding(), filter);
     sirius::gdal::SaveImage(output_image, output_filepath);
 }
 
@@ -67,56 +67,62 @@ TEST_CASE("functional tests", "[sirius]") {
     auto sinc_2_1_filter = sirius::Filter::Create(
           "./filters/sinc_zoom2_filter.tif", zoom_ratio_2_1);
 
-    auto regular_zero_padding_freq_zoom = sirius::FrequencyZoomFactory::Create(
-          sirius::ImageDecompositionPolicies::kRegular,
-          sirius::FrequencyZoomStrategies::kZeroPadding);
+    auto regular_zero_padding_freq_resampler =
+          sirius::FrequencyResamplerFactory::Create(
+                sirius::ImageDecompositionPolicies::kRegular,
+                sirius::FrequencyZoomStrategies::kZeroPadding);
 
-    auto regular_periodization_freq_zoom = sirius::FrequencyZoomFactory::Create(
-          sirius::ImageDecompositionPolicies::kRegular,
-          sirius::FrequencyZoomStrategies::kPeriodization);
+    auto regular_periodization_freq_resampler =
+          sirius::FrequencyResamplerFactory::Create(
+                sirius::ImageDecompositionPolicies::kRegular,
+                sirius::FrequencyZoomStrategies::kPeriodization);
 
-    auto periodic_smooth_zero_padding_freq_zoom =
-          sirius::FrequencyZoomFactory::Create(
+    auto periodic_smooth_zero_padding_freq_resampler =
+          sirius::FrequencyResamplerFactory::Create(
                 sirius::ImageDecompositionPolicies::kPeriodicSmooth,
                 sirius::FrequencyZoomStrategies::kZeroPadding);
 
     GenerateZoomedImage("./output/TN1.tif", lena_image, zoom_ratio_1_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN2.tif", lena_image, zoom_ratio_2_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN3.tif", disp0_image, zoom_ratio_2_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN4.tif", disp0_image, zoom_ratio_2_1,
-                        dirac_2_1_filter, *regular_zero_padding_freq_zoom);
+                        dirac_2_1_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN5.tif", lena_image, zoom_ratio_2_1,
-                        dirac_2_1_filter, *regular_zero_padding_freq_zoom);
+                        dirac_2_1_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN6.tif", disp0_image, zoom_ratio_2_1,
-                        sinc_2_1_filter, *regular_zero_padding_freq_zoom);
+                        sinc_2_1_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN7.tif", disp0_image, zoom_ratio_2_1,
-                        sinc_2_1_filter, *regular_zero_padding_freq_zoom);
+                        sinc_2_1_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN8.tif", disp0_image, zoom_ratio_2_1,
-                        sinc_2_1_filter, *regular_periodization_freq_zoom);
+                        sinc_2_1_filter, *regular_periodization_freq_resampler);
     GenerateZoomedImage("./output/TN9.tif", triangle_image, zoom_ratio_3_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN10.tif", triangle_image, zoom_ratio_3_1,
-                        no_filter, *periodic_smooth_zero_padding_freq_zoom);
+                        no_filter,
+                        *periodic_smooth_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN11.tif", door_image, zoom_ratio_3_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN12.tif", door_image, zoom_ratio_3_1,
-                        no_filter, *periodic_smooth_zero_padding_freq_zoom);
+                        no_filter,
+                        *periodic_smooth_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN13.tif", half_door_image, zoom_ratio_3_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TN14.tif", half_door_image, zoom_ratio_3_1,
-                        no_filter, *periodic_smooth_zero_padding_freq_zoom);
+                        no_filter,
+                        *periodic_smooth_zero_padding_freq_resampler);
 
     GenerateZoomedImage("./output/TF1.tif", lena_image, zoom_ratio_15_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TF2.tif", lena_255_image, zoom_ratio_2_1,
-                        no_filter, *regular_zero_padding_freq_zoom);
-    GenerateZoomedImage("./output/TF3.tif", disp0_image, zoom_ratio_7_4,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
+    GenerateZoomedImage("./output/TF3.tif", lena_image, zoom_ratio_7_4,
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TF4.tif", disp0_image, zoom_ratio_1_3,
-                        no_filter, *regular_zero_padding_freq_zoom);
+                        no_filter, *regular_zero_padding_freq_resampler);
     GenerateZoomedImage("./output/TF5.tif", triangle_image, zoom_ratio_210_120,
-                        no_filter, *periodic_smooth_zero_padding_freq_zoom);
+                        no_filter,
+                        *periodic_smooth_zero_padding_freq_resampler);
 }

--- a/tests/functional_tests.cc
+++ b/tests/functional_tests.cc
@@ -47,12 +47,13 @@ TEST_CASE("functional tests", "[sirius]") {
     LOG_SET_LEVEL(trace);
 
     sirius::ZoomRatio zoom_ratio_1_1;
-    sirius::ZoomRatio zoom_ratio_2_1(2, 1);
-    sirius::ZoomRatio zoom_ratio_3_1(3, 1);
-    sirius::ZoomRatio zoom_ratio_15_1(15, 1);
-    sirius::ZoomRatio zoom_ratio_7_4(7, 4);
-    sirius::ZoomRatio zoom_ratio_1_3(1, 3);
-    sirius::ZoomRatio zoom_ratio_210_120(210, 120);
+
+    auto zoom_ratio_2_1 = sirius::ZoomRatio::Create(2, 1);
+    auto zoom_ratio_3_1 = sirius::ZoomRatio::Create(3, 1);
+    auto zoom_ratio_15_1 = sirius::ZoomRatio::Create(15, 1);
+    auto zoom_ratio_7_4 = sirius::ZoomRatio::Create(7, 4);
+    auto zoom_ratio_1_3 = sirius::ZoomRatio::Create(1, 3);
+    auto zoom_ratio_210_120 = sirius::ZoomRatio::Create(210, 120);
 
     auto lena_image = sirius::gdal::LoadImage("./input/lena.jpg");
     auto lena_255_image = sirius::gdal::LoadImage("./input/lena-255x255.tif");

--- a/tests/types_tests.cc
+++ b/tests/types_tests.cc
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2018 CS - Systemes d'Information (CS-SI)
+ *
+ * This file is part of Sirius
+ *
+ *     https://github.com/CS-SI/SIRIUS
+ *
+ * Sirius is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Sirius is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Sirius.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch/catch.hpp>
+
+#include "sirius/types.h"
+
+TEST_CASE("types tests - ZoomRatio from int", "[sirius]") {
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create(1, 1));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create(2, 1));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create(2));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create(14, 10));
+
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(-1));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(1, -1));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(0, 1));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(1, 0));
+}
+
+TEST_CASE("types tests - ZoomRatio from string", "[sirius]") {
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create("1:1"));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create("2:1"));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create("2"));
+    REQUIRE_NOTHROW(sirius::ZoomRatio::Create("14:10"));
+
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(":"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("-"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create(":1"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("1:"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("-:"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("-:-"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("-2:1"));
+    REQUIRE_THROWS(sirius::ZoomRatio::Create("2:-1"));
+}


### PR DESCRIPTION
This PR should fix #4, fix #5, fix #6, fix #7, fix #8 and fix #9 

Changes are mainly related to sirius CLI interface. Here is the new proposal:

```
Sirius X.Y.Z (...)
Standalone tool to resample and filter images in the frequency domain

Usage:
  ./sirius [OPTION...] input-image output-image

  -h, --help           Show help
  -v, --verbosity arg  Set verbosity level
                       (trace,debug,info,warn,err,critical,off) (default: info)

 resampling options:
  -r, --resampling-ratio arg    Resampling ratio as input:output, allowed
                                format: I (equivalent to I:1), I:O (default: 1:1)
      --no-image-decomposition  Do not decompose the input image (default:
                                periodic plus smooth image decomposition)
      --upsample-periodization  Force periodization as upsampling algorithm
                                (default algorithm if a filter is provided). A
                                filter is required to use this algorithm
      --upsample-zero-padding   Force zero padding as upsampling algorithm
                                (default algorithm if no filter is provided)

 filter options:
      --filter arg           Path to the filter image to apply to the source
                             or resampled image
      --filter-normalize     Normalize filter coefficients (default is no
                             normalization)
      --zero-pad-real-edges  Force zero padding strategy on real input edges
                             (default: mirror padding)

 streaming options:
      --stream                  Enable stream mode
      --block-width arg         Initial width of a stream block (default:
                                256)
      --block-height arg        Initial height of a stream block (default:
                                256)
      --no-block-resizing       Disable block resizing optimization
      --parallel-workers [=arg(=1)]
                                Parallel workers used to compute resampling
                                (8 max) (default: 1)
```

README was updated to comply with this proposal.
Zoom API was renamed to comply with resampling term.