### PR TITLE
handle uncentered filters. remove CreateEvenImage

### DIFF
--- a/src/sirius/filter.cc
+++ b/src/sirius/filter.cc
@@ -40,16 +40,28 @@ namespace sirius {
 
 Image ZoomFilterImageToInputResolution(const Image& filter_image,
                                        const ZoomRatio& zoom_ratio);
+
 void NormalizeFilterImage(Image& filter_image, int oversampling);
-Image FrequencyShift(const Image& filter_image);
+
+Image FrequencyShift(const Image& filter_image, const Point& hot_point,
+                     float shift_col, float shift_row);
+
+Image CenterFilterImage(const Image& filter_image, const Point& hot_point);
 
 Filter Filter::Create(const std::string& image_path,
-                      const ZoomRatio& zoom_ratio, PaddingType padding_type,
-                      bool normalize) {
+                      const ZoomRatio& zoom_ratio, const Point& hot_point,
+                      PaddingType padding_type, bool filter_normalize) {
     // load image
     auto filter_image = gdal::LoadImage(image_path);
 
-    if (normalize) {
+    if (hot_point.x < -1 || hot_point.x >= filter_image.size.col ||
+        hot_point.y < -1 || hot_point.y >= filter_image.size.row) {
+        LOG("filter", error, "Invalid hot point with coordinates {}, {}",
+            hot_point.x, hot_point.y);
+        throw SiriusException("Invalid hot point");
+    }
+
+    if (filter_normalize) {
         NormalizeFilterImage(filter_image, zoom_ratio.input_resolution());
     }
 
@@ -58,22 +70,24 @@ Filter Filter::Create(const std::string& image_path,
 
     if (zoom_ratio.ratio() <= 1) {
         return CreateZoomOutFilter(std::move(filter_image), zoom_ratio,
-                                   padding_type);
+                                   padding_type, hot_point);
     } else if (!zoom_ratio.IsRealZoom()) {
         return CreateZoomInFilter(std::move(filter_image), zoom_ratio,
-                                  padding_type);
+                                  padding_type, hot_point);
     } else {
         return CreateRealZoomFilter(std::move(filter_image), zoom_ratio,
-                                    padding_type);
+                                    padding_type, hot_point);
     }
 }
 
 Filter::Filter(Image&& filter_image, const Size& padding_size,
-               const ZoomRatio& zoom_ratio, PaddingType padding_type)
+               const ZoomRatio& zoom_ratio, PaddingType padding_type,
+               const Point& hot_point)
     : filter_(std::move(filter_image)),
       padding_size_(padding_size),
       zoom_ratio_(zoom_ratio),
       padding_type_(padding_type),
+      hot_point_(hot_point),
       filter_fft_cache_(std::make_unique<FilterFFTCache>()) {
     LOG("filter", info, "filter size: {}x{}", filter_.size.row,
         filter_.size.col);
@@ -164,8 +178,13 @@ fftw::ComplexUPtr Filter::CreateFilterFFT(const Size& image_size) const {
 
 Filter Filter::CreateZoomOutFilter(Image filter_image,
                                    const ZoomRatio& zoom_ratio,
-                                   PaddingType padding_type) {
+                                   PaddingType padding_type,
+                                   const Point& hot_point) {
     LOG("filter", info, "filter: downsampling");
+    if (hot_point.x != -1 && hot_point.y != -1) {
+        filter_image = CenterFilterImage(filter_image, hot_point);
+    }
+
     int padding_row = (filter_image.size.row % 2 == 0)
                             ? (filter_image.size.row / 2)
                             : (filter_image.size.row - 1) / 2;
@@ -176,13 +195,19 @@ Filter Filter::CreateZoomOutFilter(Image filter_image,
     return {std::move(filter_image),
             {padding_row, padding_col},
             zoom_ratio,
-            padding_type};
+            padding_type,
+            hot_point};
 }
 
 Filter Filter::CreateZoomInFilter(Image filter_image,
                                   const ZoomRatio& zoom_ratio,
-                                  PaddingType padding_type) {
+                                  PaddingType padding_type,
+                                  const Point& hot_point) {
     LOG("filter", info, "filter: upsampling");
+    if (hot_point.x != -1 && hot_point.y != -1) {
+        filter_image = CenterFilterImage(filter_image, hot_point);
+    }
+
     int padding_row = static_cast<int>(
           ((filter_image.size.row - 1) / 2) *
           (zoom_ratio.output_resolution() /
@@ -207,15 +232,21 @@ Filter Filter::CreateZoomInFilter(Image filter_image,
     return {std::move(filter_image),
             {padding_row, padding_col},
             zoom_ratio,
-            padding_type};
+            padding_type,
+            hot_point};
 }
 
 Filter Filter::CreateRealZoomFilter(Image filter_image,
                                     const ZoomRatio& zoom_ratio,
-                                    PaddingType padding_type) {
+                                    PaddingType padding_type,
+                                    const Point& hot_point) {
     LOG("filter", info,
         "filter: float upsampling factor (upsample filter to input "
         "resolution)");
+    if (hot_point.x != -1 && hot_point.y != 1) {
+        filter_image = CenterFilterImage(filter_image, hot_point);
+    }
+
     // zoom filter image to input resolution
     filter_image = ZoomFilterImageToInputResolution(filter_image, zoom_ratio);
 
@@ -236,7 +267,8 @@ Filter Filter::CreateRealZoomFilter(Image filter_image,
     return {std::move(filter_image),
             {padding_row, padding_col},
             zoom_ratio,
-            padding_type};
+            padding_type,
+            hot_point};
 }
 
 Image ZoomFilterImageToInputResolution(const Image& filter_image,
@@ -259,6 +291,7 @@ Image ZoomFilterImageToInputResolution(const Image& filter_image,
           new_zoom_ratio, shifted_filter, {0, 0, 0, 0}, {});
 
     Image unshifted_zoomed_filter(zoomed_filter.size);
+    // centered FFTShift so filter's hot point remains centered
     utils::FFTShift2D(zoomed_filter.data.data(), zoomed_filter.size,
                       unshifted_zoomed_filter.data.data());
 
@@ -297,11 +330,19 @@ void NormalizeFilterImage(Image& filter_image, int oversampling) {
     }
 }
 
-Image FrequencyShift(const Image& filter_image) {
+Image FrequencyShift(const Image& filter_image, const Point& hot_point,
+                     float shift_row, float shift_col) {
     LOG("filter", info, "apply frequency shift to the filter");
     Image shifted_filter(filter_image.size);
-    utils::IFFTShift2D(filter_image.data.data(), filter_image.size,
-                       shifted_filter.data.data());
+
+    if (hot_point.x == -1 && hot_point.y == -1) {
+        utils::IFFTShift2D(filter_image.data.data(), filter_image.size,
+                           shifted_filter.data.data());
+    } else {
+        utils::IFFTShift2DUncentered(filter_image.data.data(),
+                                     filter_image.size, hot_point,
+                                     shifted_filter.data.data());
+    }
 
     auto fft_filter =
           fftw::FFT(shifted_filter.data.data(), shifted_filter.size);
@@ -316,13 +357,13 @@ Image FrequencyShift(const Image& filter_image) {
     auto exp_cplx_x = fftw::CreateComplex({fft_row_count, 1});
 
     for (int j = 0; j < fft_col_count; ++j) {
-        exp_cplx_y.get()[j][0] = cos(-2 * M_PI * (-0.5) * freq_y[j]);
-        exp_cplx_y.get()[j][1] = sin(-2 * M_PI * (-0.5) * freq_y[j]);
+        exp_cplx_y.get()[j][0] = cos(-2 * M_PI * shift_row * freq_y[j]);
+        exp_cplx_y.get()[j][1] = sin(-2 * M_PI * shift_row * freq_y[j]);
     }
 
     for (int i = 0; i < fft_row_count; ++i) {
-        exp_cplx_x.get()[i][0] = cos(-2 * M_PI * (-0.5) * freq_x[i]);
-        exp_cplx_x.get()[i][1] = sin(-2 * M_PI * (-0.5) * freq_x[i]);
+        exp_cplx_x.get()[i][0] = cos(-2 * M_PI * shift_col * freq_x[i]);
+        exp_cplx_x.get()[i][1] = sin(-2 * M_PI * shift_col * freq_x[i]);
     }
 
     for (int i = 0; i < fft_row_count; ++i) {
@@ -350,20 +391,32 @@ Image FrequencyShift(const Image& filter_image) {
 
     shifted_filter = fftw::IFFT(shifted_filter.size, std::move(fft_filter));
     Image unshifted_filter(shifted_filter.size);
-    utils::FFTShift2D(shifted_filter.data.data(), unshifted_filter.size,
-                      unshifted_filter.data.data());
 
-    // remove last row and col
-    Image result_filter(
-          {unshifted_filter.size.row - 1, unshifted_filter.size.col - 1});
-    for (int i = 0; i < result_filter.size.row; ++i) {
-        for (int j = 0; j < result_filter.size.col; ++j) {
-            result_filter.data[i * result_filter.size.col + j] =
-                  unshifted_filter.data[i * unshifted_filter.size.col + j];
-        }
+    if (hot_point.x == -1 && hot_point.y == -1) {
+        utils::FFTShift2D(shifted_filter.data.data(), unshifted_filter.size,
+                          unshifted_filter.data.data());
+    } else {
+        utils::FFTShift2DUncentered(shifted_filter.data.data(),
+                                    unshifted_filter.size, hot_point,
+                                    unshifted_filter.data.data());
     }
 
-    return result_filter;
+    return unshifted_filter;
+}
+
+Image CenterFilterImage(const Image& filter_image, const Point& hot_point) {
+    LOG("filter", trace, "center filter image");
+
+    auto shifted_values =
+          fftw::CreateReal({filter_image.size.row, filter_image.size.col});
+    utils::IFFTShift2DUncentered(filter_image.data.data(), filter_image.size,
+                                 hot_point, shifted_values.get());
+    Image centered_filter(filter_image.size);
+    // centered FFTShift so filter's hot point remains centered
+    utils::FFTShift2D(shifted_values.get(), filter_image.size,
+                      centered_filter.data.data());
+
+    return centered_filter;
 }
 
 }  // namespace sirius

--- a/src/sirius/filter.h
+++ b/src/sirius/filter.h
@@ -59,14 +59,13 @@ class Filter {
      * \param image_path image path of the filter
      * \param zoom_ratio ratio on which the filter must be applied
      * \param padding_type padding type
-     * \param normalize normalize filter
      *
      * \throw SiriusException if the filter image cannot be loaded
      */
     static Filter Create(const std::string& image_path,
-                         const ZoomRatio& zoom_ratio,
+                         const ZoomRatio& zoom_ratio, const Point& hot_point,
                          PaddingType padding_type = PaddingType::kMirrorPadding,
-                         bool normalize = false);
+                         bool filter_normalize = false);
 
     Filter() = default;
 
@@ -116,6 +115,8 @@ class Filter {
                 padding_size_.col, padding_type_};
     }
 
+    Point hot_point() const { return hot_point_; }
+
     /**
      * \brief Check that the filter can be applied on the given zoom ratio
      * \param zoom_ratio
@@ -143,16 +144,20 @@ class Filter {
   private:
     static Filter CreateZoomInFilter(Image filter_image,
                                      const ZoomRatio& zoom_ratio,
-                                     PaddingType padding_type);
+                                     PaddingType padding_type,
+                                     const Point& hot_point);
     static Filter CreateZoomOutFilter(Image filter_image,
                                       const ZoomRatio& zoom_ratio,
-                                      PaddingType padding_type);
+                                      PaddingType padding_type,
+                                      const Point& hot_point);
     static Filter CreateRealZoomFilter(Image filter_image,
                                        const ZoomRatio& zoom_ratio,
-                                       PaddingType padding_type);
+                                       PaddingType padding_type,
+                                       const Point& hot_point);
 
     Filter(Image&& filter_image, const Size& padding_size,
-           const ZoomRatio& zoom_ratio, PaddingType padding_type);
+           const ZoomRatio& zoom_ratio, PaddingType padding_type,
+           const Point& hot_point);
 
     fftw::ComplexUPtr CreateFilterFFT(const Size& image_size) const;
 
@@ -161,6 +166,7 @@ class Filter {
     Size padding_size_{0, 0};
     ZoomRatio zoom_ratio_{};
     PaddingType padding_type_{PaddingType::kMirrorPadding};
+    Point hot_point_;
 
     FilterFFTCacheUPtr filter_fft_cache_{nullptr};
 };

--- a/src/sirius/resampler/frequency_resampler.txx
+++ b/src/sirius/resampler/frequency_resampler.txx
@@ -54,10 +54,6 @@ Image FrequencyResampler<ImageDecompositionPolicy, ZoomStrategy>::Compute(
     LOG("frequency_resampler", trace, "pad image");
     auto padded_image = input_image.CreatePaddedImage(image_padding);
 
-    if (padded_image.size.col % 2 != 0 || padded_image.size.row % 2 != 0) {
-        padded_image.CreateEvenImage();
-    }
-
     LOG("frequency_resampler", trace, "decompose and zoom image");
     // method inherited from ImageDecompositionPolicy
     Image result_image = this->DecomposeAndZoom(zoom_ratio.input_resolution(),

--- a/src/sirius/types.h
+++ b/src/sirius/types.h
@@ -80,6 +80,21 @@ struct Size {
     int col{0};
 };
 
+struct Point {
+    Point() = default;
+
+    Point(int x, int y) : x(x), y(y) {}
+
+    ~Point() = default;
+    Point(const Point&) = default;
+    Point& operator=(const Point&) = default;
+    Point(Point&&) = default;
+    Point& operator=(Point&&) = default;
+
+    int x{0};
+    int y{0};
+};
+
 /**
  * \brief Data class that represents zoom ratio as
  *        input_resolution/output_resolution

--- a/src/sirius/utils/numeric.cc
+++ b/src/sirius/utils/numeric.cc
@@ -71,6 +71,114 @@ void IFFTShift2D(const double* data, const Size& size, double* shifted_data) {
     }
 }
 
+void IFFTShift2DUncentered(const double* data, const Size& size,
+                           const Point& hot_point, double* shifted_data) {
+    Size block_4(size.row - hot_point.y, size.col - hot_point.x);
+    Size block_3(block_4.row, hot_point.x);
+    Size block_2(hot_point.y, block_4.col);
+    Size block_1(hot_point.y, hot_point.x);
+
+    Point p4_shifted(0, 0);  // block4 top left corner after shift
+    Point p3_shifted(block_4.col, 0);
+    Point p2_shifted(0, block_4.row);
+    Point p1_shifted(block_4.col, block_4.row);
+
+    Point p4 = hot_point;  // block4 top left corner in source image
+    Point p3(0, size.row - block_4.row);
+    Point p2(p4.x, 0);
+    Point p1(0, 0);
+
+    int begin = p4_shifted.x + p4_shifted.y * size.col;
+    int begin_src = p4.x + p4.y * size.col;
+    for (int i = 0; i < block_4.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_4.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p3_shifted.x + p3_shifted.y * size.col;
+    begin_src = p3.x + p3.y * size.col;
+    for (int i = 0; i < block_3.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_3.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p2_shifted.x + p2_shifted.y * size.col;
+    begin_src = p2.x + p2.y * size.col;
+    for (int i = 0; i < block_2.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_2.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p1_shifted.x + p1_shifted.y * size.col;
+    begin_src = p1.x + p1.y * size.col;
+    for (int i = 0; i < block_1.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_1.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+}
+
+void FFTShift2DUncentered(const double* data, const Size& size,
+                          const Point& hot_point, double* shifted_data) {
+    Size block_4(size.row - hot_point.y, size.col - hot_point.x);
+    Size block_3(block_4.row, hot_point.x);
+    Size block_2(hot_point.y, block_4.col);
+    Size block_1(hot_point.y, hot_point.x);
+
+    Point p4(0, 0);  // block4 top left corner in source image
+    Point p3(block_4.col, 0);
+    Point p2(0, block_4.row);
+    Point p1(block_4.col, block_4.row);
+
+    Point p4_shifted = hot_point;  // block4 top left corner after shift
+    Point p3_shifted(0, size.row - block_4.row);
+    Point p2_shifted(p4_shifted.x, 0);
+    Point p1_shifted(0, 0);
+
+    int begin = p4_shifted.x + p4_shifted.y * size.col;
+    int begin_src = p4.x + p4.y * size.col;
+    for (int i = 0; i < block_4.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_4.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p3_shifted.x + p3_shifted.y * size.col;
+    begin_src = p3.x + p3.y * size.col;
+    for (int i = 0; i < block_3.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_3.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p2_shifted.x + p2_shifted.y * size.col;
+    begin_src = p2.x + p2.y * size.col;
+    for (int i = 0; i < block_2.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_2.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+
+    begin = p1_shifted.x + p1_shifted.y * size.col;
+    begin_src = p1.x + p1.y * size.col;
+    for (int i = 0; i < block_1.row; ++i) {
+        memcpy(&shifted_data[begin], &data[begin_src],
+               block_1.col * sizeof(double));
+        begin += size.col;
+        begin_src += size.col;
+    }
+}
+
 Size GenerateDyadicSize(const Size& size, const int res_in,
                         const Size& padding_size) {
     int h = size.row;

--- a/src/sirius/utils/numeric.h
+++ b/src/sirius/utils/numeric.h
@@ -44,6 +44,27 @@ void FFTShift2D(const double* data, const Size& size, double* shifted_data);
 void IFFTShift2D(const double* data, const Size& size, double* shifted_data);
 
 /**
+ * \brief IFFTShift 2D matrix in which hot point is not centered
+ * \param data input data
+ * \param size dimensions of the image to be shifted
+ * \param hot_point hot point coordinates
+ * \param shifted_data output data
+ */
+void IFFTShift2DUncentered(const double* data, const Size& size,
+                           const Point& hot_point, double* shifted_data);
+
+/**
+ * \brief FFTShift 2D matrix in which hot point must remain uncentered after
+ * shift
+ * \param data input data
+ * \param size dimensions of the image to be shifted
+ * \param hot_point hot point coordinates
+ * \param shifted_data output data
+ */
+void FFTShift2DUncentered(const double* data, const Size& size,
+                          const Point& hot_point, double* shifted_data);
+
+/**
  * \brief Compute frequencies for which fft will be calculated
  * \param n_samples width of the spatial signal (expected to be odd)
  * \param half decide to return only half the frequencies

--- a/tests/utils_tests.cc
+++ b/tests/utils_tests.cc
@@ -189,6 +189,148 @@ TEST_CASE("utils tests - IFFTShift2D(FFTShift2D)", "[sirius]") {
     }
 }
 
+TEST_CASE("utils tests - IFFTShift2DUncentered", "[sirius]") {
+    LOG_SET_LEVEL(trace);
+
+    SECTION("IFFTShift2DUncentered - odd row, odd col") {
+        std::vector<double> input{0, 1, 2, 3, 4, 5, 6, 7,
+                                  8, 9, 10, 11, 12, 13, 14, 15,
+                                  16, 17, 18, 19, 20, 21, 22, 23, 24};
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{18, 19, 15, 16, 17, 23, 24, 20,
+                                   21, 22, 3, 4, 0, 1, 2, 8, 9, 5, 6, 7,
+                                   13, 14, 10, 11, 12};
+
+        sirius::utils::IFFTShift2DUncentered(input.data(), {5, 5}, {3, 3}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+	SECTION("IFFTShift2DUncentered - odd row, odd col") {
+        std::vector<double> input{0, 1, 2, 3, 4, 5, 6, 7,
+                                  8, 9, 10, 11, 12, 13, 14, 15,
+                                  16, 17, 18, 19, 20, 21, 22, 23, 24};
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{24, 20, 21, 22, 23, 4, 0, 1,
+                                   2, 3, 9, 5, 6, 7, 8, 14, 10, 11, 12, 13,
+                                   19, 15, 16, 17, 18};
+
+        sirius::utils::IFFTShift2DUncentered(input.data(), {5, 5}, {4, 4}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+    SECTION("IFFTShift2DUncentered - even row, even col") {
+        std::vector<double> input{0, 1, 2, 3, 4, 5, 6, 7,
+                                  8, 9, 10, 11, 12, 13, 14, 15,
+                                 };
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 1, 2, 3, 0};
+
+        sirius::utils::IFFTShift2DUncentered(input.data(), {4, 4}, {1, 1}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+	SECTION("IFFTShift2DUncentered - even row, odd col") {
+        std::vector<double> input{0, 1, 2, 3, 4, 5, 6, 7,
+                                  8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+                                  18, 19
+                                 };
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{8, 9, 5, 6, 7, 13, 14, 10, 11, 12, 18, 19, 15, 16, 17,
+								   3, 4, 0, 1, 2};
+
+        sirius::utils::IFFTShift2DUncentered(input.data(), {4, 5}, {3, 1}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+    SECTION("IFFTShift2DUncentered - odd row, even col") {
+        std::vector<double> input{0, 1, 2, 3, 4, 5, 6, 7,
+                                  8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+                                  18, 19
+                                 };
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 17, 18, 19, 16};
+
+        sirius::utils::IFFTShift2DUncentered(input.data(), {5, 4}, {1, 0}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+}
+
+TEST_CASE("utils tests - FFTShift2DUncentered", "[sirius]") {
+    LOG_SET_LEVEL(trace);
+
+    SECTION("FFTShift2DUncentered - odd row, odd col") {
+        std::vector<double> input{18, 19, 15, 16, 17, 23, 24, 20,
+                                  21, 22, 3, 4, 0, 1, 2, 8, 9, 5, 6, 7,
+                                  13, 14, 10, 11, 12,};
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{0, 1, 2, 3, 4, 5, 6, 7,
+								   8, 9, 10, 11, 12, 13, 14, 15,
+                                   16, 17, 18, 19, 20, 21, 22, 23, 24};
+
+        sirius::utils::FFTShift2DUncentered(input.data(), {5, 5}, {3, 3}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+	SECTION("FFTShift2DUncentered - odd row, odd col") {
+        std::vector<double> input{24, 20, 21, 22, 23, 4, 0, 1,
+                                  2, 3, 9, 5, 6, 7, 8, 14, 10, 11, 12, 13,
+                                  19, 15, 16, 17, 18};
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{0, 1, 2, 3, 4, 5, 6, 7,
+                                   8, 9, 10, 11, 12, 13, 14, 15,
+                                   16, 17, 18, 19, 20, 21, 22, 23, 24};
+
+        sirius::utils::FFTShift2DUncentered(input.data(), {5, 5}, {4, 4}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+    SECTION("FFTShift2DUncentered - even row, even col") {
+        std::vector<double> input{5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 1, 2, 3, 0};
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{ 0, 1, 2, 3, 4, 5, 6, 7,
+                                    8, 9, 10, 11, 12, 13, 14, 15};
+
+        sirius::utils::FFTShift2DUncentered(input.data(), {4, 4}, {1, 1}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+	SECTION("FFTShift2DUncentered - even row, odd col") {
+        std::vector<double> input{8, 9, 5, 6, 7, 13, 14, 10, 11, 12, 18, 19, 15, 16, 17,
+								  3, 4, 0, 1, 2
+                                 };
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{0, 1, 2, 3, 4, 5, 6, 7,
+                                   8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+                                   18, 19};
+
+        sirius::utils::FFTShift2DUncentered(input.data(), {4, 5}, {3, 1}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+    
+    SECTION("FFTShift2DUncentered - odd row, even col") {
+        std::vector<double> input{1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13,
+								  14, 15, 12, 17, 18, 19, 16
+                                 };
+        std::vector<double> shifted_output(input.size());
+        std::vector<double> output{0, 1, 2, 3, 4, 5, 6, 7,
+                                   8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+                                   18, 19};
+
+        sirius::utils::FFTShift2DUncentered(input.data(), {5, 4}, {1, 0}, shifted_output.data());
+        REQUIRE(std::equal(output.cbegin(), output.cend(),
+                           shifted_output.cbegin()));
+    }
+}
+
 TEST_CASE("utils test - LRU cache", "[sirius]") {
     struct DummyStruct {
         DummyStruct() = default;


### PR DESCRIPTION
Allow user to give uncentered filters by specifying its hot point coordinates.