### PR TITLE
siriuspy: python bindings for SIRIUS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(ENABLE_LOGS "Enable logs" ON)
 option(ENABLE_GSL_CONTRACTS "Enable GSL contracts" OFF)
 option(ENABLE_DOCUMENTATION "Enable documentation generation" OFF)
 option(ENABLE_UNIT_TESTS "Enable unit test targets" OFF)
+option(ENABLE_BINDINGS "Enable unit test targets" OFF)
 
 # path to additional cmake modules
 list(APPEND CMAKE_MODULE_PATH
@@ -101,6 +102,10 @@ add_subdirectory(src)
 if (${ENABLE_UNIT_TESTS})
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+if(ENABLE_BINDINGS)
+  add_subdirectory(bindings)
 endif()
 
 if (${ENABLE_DOCUMENTATION})

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(SIRIUS_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src")
+set(SIRIUS_LIBRARY_DIR "${PROJECT_BINARY_DIR}/src")
+set(SPDLOG_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/third_party/spdlog/spdlog/include")
+find_path(PYBIND11_INCLUDE_DIR pybind11/pybind11.h)
+if(NOT PYBIND11_INCLUDE_DIR)
+  message(FATAL_ERROR "Cannot find PYBIND11_INCLUDE_DIR")
+endif()
+
+find_package ( PythonInterp 3.0 REQUIRED)
+
+configure_file(setup.cfg.in ${CMAKE_CURRENT_SOURCE_DIR}/setup.cfg )
+
+set(stamp_file "${CMAKE_CURRENT_BINARY_DIR}/stamp.build")
+add_custom_command(OUTPUT "${stamp_file}"
+  COMMAND ${PYTHON_EXECUTABLE} setup.py build --build-lib ${CMAKE_CURRENT_BINARY_DIR} --define SIRIUS_ENABLE_LOGS=${SIRIUS_ENABLE_LOGS} --define SIRIUS_ENABLE_CACHE_OPTIMIZATION=${SIRIUS_ENABLE_CACHE_OPTIMIZATION}
+  COMMAND ${CMAKE_COMMAND} -E touch "${stamp_file}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "${PYTHON_EXECUTABLE} setup.py build"
+  VERBATIM)
+
+add_custom_target(siriuspy ALL DEPENDS libsirius ${stamp_file})
+
+add_custom_target(test_siriuspy COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py)
+
+#python3 setup.py build_ext --include-dirs=SIRIUS_INCLUDE_DIR:PYBIND11_INCLUDE_DIR:FFTW_INCLUDE_DIR --library-dirs=SIRIUS_LIB_DIR
+

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -19,7 +19,8 @@ add_custom_command(OUTPUT "${stamp_file}"
 
 add_custom_target(siriuspy ALL DEPENDS libsirius ${stamp_file})
 
-add_custom_target(test_siriuspy COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} -m unittest test.py  -v)
-
+if(UNIX)
+  add_custom_target(test_siriuspy COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} env LD_LIBRARY_PATH=${SIRIUS_LIBRARY_DIR} PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} -m unittest test.py  -v)
+endif()
 #python3 setup.py build_ext --include-dirs=SIRIUS_INCLUDE_DIR:PYBIND11_INCLUDE_DIR:FFTW_INCLUDE_DIR --library-dirs=SIRIUS_LIB_DIR
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_command(OUTPUT "${stamp_file}"
 
 add_custom_target(siriuspy ALL DEPENDS libsirius ${stamp_file})
 
-add_custom_target(test_siriuspy COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py)
+add_custom_target(test_siriuspy COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} -m unittest test.py  -v)
 
 #python3 setup.py build_ext --include-dirs=SIRIUS_INCLUDE_DIR:PYBIND11_INCLUDE_DIR:FFTW_INCLUDE_DIR --library-dirs=SIRIUS_LIB_DIR
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -7,15 +7,14 @@ if(NOT PYBIND11_INCLUDE_DIR)
 endif()
 
 find_package ( PythonInterp 3.0 REQUIRED)
-
 configure_file(setup.cfg.in ${CMAKE_CURRENT_SOURCE_DIR}/setup.cfg )
 
 set(stamp_file "${CMAKE_CURRENT_BINARY_DIR}/stamp.build")
 add_custom_command(OUTPUT "${stamp_file}"
-  COMMAND ${PYTHON_EXECUTABLE} setup.py build --build-lib ${CMAKE_CURRENT_BINARY_DIR} --define SIRIUS_ENABLE_LOGS=${SIRIUS_ENABLE_LOGS} --define SIRIUS_ENABLE_CACHE_OPTIMIZATION=${SIRIUS_ENABLE_CACHE_OPTIMIZATION}
+  COMMAND ${PYTHON_EXECUTABLE} setup.py build --build-lib ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${CMAKE_COMMAND} -E touch "${stamp_file}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "${PYTHON_EXECUTABLE} setup.py build"
+  COMMENT "${PYTHON_EXECUTABLE} setup.py build --build-lib ${CMAKE_CURRENT_BINARY_DIR}"
   VERBATIM)
 
 add_custom_target(siriuspy ALL DEPENDS libsirius ${stamp_file})

--- a/bindings/setup.cfg.in
+++ b/bindings/setup.cfg.in
@@ -1,0 +1,7 @@
+[metadata]
+version = @SIRIUS_VERSION@
+
+[build_ext]
+#inplace=1
+include_dirs=@SIRIUS_INCLUDE_DIR@:@PYBIND11_INCLUDE_DIR@:@FFTW3_INCLUDE_DIR@:@SPDLOG_INCLUDE_DIR@
+library_dirs=@SIRIUS_LIBRARY_DIR@

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -1,0 +1,73 @@
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+import sys
+import setuptools
+
+ext_modules = [
+    Extension('siriuspy',
+        sources=['siriuspy.cpp'],
+        libraries=['libsirius'],
+        language='c++'
+    ),
+]
+
+# As of Python 3.6, CCompiler has a `has_flag` method.
+# cf http://bugs.python.org/issue26689
+def has_flag(compiler, flagname):
+    """Return a boolean indicating whether a flag name is supported on
+    the specified compiler.
+    """
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
+        f.write('int main (int argc, char **argv) { return 0; }')
+        try:
+            compiler.compile([f.name], extra_postargs=[flagname])
+        except setuptools.distutils.errors.CompileError:
+            return False
+    return True
+
+
+def cpp_flag(compiler):
+    """Return the -std=c++14 compiler flag. this is required minimum for sirius"""
+    if has_flag(compiler, '-std=c++14'):
+        return '-std=c++14'
+    else:
+        raise RuntimeError('Unsupported compiler -- at least C++11 support '
+                           'is needed!')
+
+class BuildExt(build_ext):
+    """A custom build extension for adding compiler-specific options."""
+    c_opts = {
+        'msvc': ['/EHsc'],
+        'unix': [],
+    }
+
+    if sys.platform == 'darwin':
+        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+
+    def build_extensions(self):
+        ct = self.compiler.compiler_type
+        opts = self.c_opts.get(ct, [])
+        if ct == 'unix':
+            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
+            opts.append(cpp_flag(self.compiler))
+            if has_flag(self.compiler, '-fvisibility=hidden'):
+                opts.append('-fvisibility=hidden')
+        elif ct == 'msvc':
+            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+        for ext in self.extensions:
+            ext.extra_compile_args = opts
+        build_ext.build_extensions(self)
+
+setup(
+    name='siriuspy',
+    author='CS-SI',
+    author_email='github.com/CS-SI/SIRIUS',
+    url='github.com/CS-SI/SIRIUS',
+    description='Python bindings for SIRIUS',
+    long_description='Fast and simple to plug-in C++ resampling library that is taking advantage of the Fourier Transform',
+    ext_modules=ext_modules,
+    #install_requires=['pybind11>=2.2'],
+    cmdclass={'build_ext': BuildExt},
+    zip_safe=False,
+)

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -1,63 +1,29 @@
-from setuptools import setup, Extension
+import os, sysconfig
+from setuptools import setup, Extension, distutils
 from setuptools.command.build_ext import build_ext
-import sys
-import setuptools
+from setuptools.dist import Distribution
+
+class BinaryDistribution(Distribution):
+    def is_pure(self):
+        return False
+
+extra_compile_args = sysconfig.get_config_var('CFLAGS').split()
+extra_compile_args.append('-std=c++14')
+#TODO: use generated config.h and avoid SIRIUS_ENABLE_LOGS and others
+extra_compile_args.append('-DSIRIUS_ENABLE_LOGS=1')
+
+# extra_compile_args.append(cpp_flag(self.compiler))
+# if has_flag(self.compiler, '-fvisibility=hidden'):
+#     opts.append('-fvisibility=hidden')
 
 ext_modules = [
-    Extension('siriuspy',
+    Extension(name='siriuspy',
         sources=['siriuspy.cpp'],
         libraries=['libsirius'],
+        extra_compile_args=extra_compile_args,
         language='c++'
     ),
 ]
-
-# As of Python 3.6, CCompiler has a `has_flag` method.
-# cf http://bugs.python.org/issue26689
-def has_flag(compiler, flagname):
-    """Return a boolean indicating whether a flag name is supported on
-    the specified compiler.
-    """
-    import tempfile
-    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
-        f.write('int main (int argc, char **argv) { return 0; }')
-        try:
-            compiler.compile([f.name], extra_postargs=[flagname])
-        except setuptools.distutils.errors.CompileError:
-            return False
-    return True
-
-
-def cpp_flag(compiler):
-    """Return the -std=c++14 compiler flag. this is required minimum for sirius"""
-    if has_flag(compiler, '-std=c++14'):
-        return '-std=c++14'
-    else:
-        raise RuntimeError('Unsupported compiler -- at least C++11 support '
-                           'is needed!')
-
-class BuildExt(build_ext):
-    """A custom build extension for adding compiler-specific options."""
-    c_opts = {
-        'msvc': ['/EHsc'],
-        'unix': [],
-    }
-
-    if sys.platform == 'darwin':
-        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
-
-    def build_extensions(self):
-        ct = self.compiler.compiler_type
-        opts = self.c_opts.get(ct, [])
-        if ct == 'unix':
-            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
-            opts.append(cpp_flag(self.compiler))
-            if has_flag(self.compiler, '-fvisibility=hidden'):
-                opts.append('-fvisibility=hidden')
-        elif ct == 'msvc':
-            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
-        for ext in self.extensions:
-            ext.extra_compile_args = opts
-        build_ext.build_extensions(self)
 
 setup(
     name='siriuspy',
@@ -68,6 +34,6 @@ setup(
     long_description='Fast and simple to plug-in C++ resampling library that is taking advantage of the Fourier Transform',
     ext_modules=ext_modules,
     #install_requires=['pybind11>=2.2'],
-    cmdclass={'build_ext': BuildExt},
-    zip_safe=False,
+    #cmdclass={'build_ext': Extension},
+    zip_safe=False
 )

--- a/bindings/siriuspy.cpp
+++ b/bindings/siriuspy.cpp
@@ -1,0 +1,120 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include "sirius/filter.h"
+#include "sirius/types.h"
+#include "sirius/image.h"
+#include "sirius/frequency_resampler_factory.h"
+#include "sirius/i_frequency_resampler.h"
+
+#include "sirius/utils/log.h"
+#include <spdlog/spdlog.h>
+
+namespace py = pybind11;
+
+//using namespace sirius;
+py::array_t<double> resampler(py::buffer input_array, int input_resolution, py::kwargs kwargs) {
+  int output_resolution = 1;
+  sirius::FrequencyZoomStrategies zoom_strategy = sirius::FrequencyZoomStrategies::kZeroPadding;
+  sirius::ImageDecompositionPolicies image_decomposition = sirius::ImageDecompositionPolicies::kPeriodicSmooth;
+  sirius::Padding image_padding(0,0,0,0);
+  sirius::Filter filter  = {};
+  sirius::ZoomRatio zoom_ratio = sirius::ZoomRatio::Create(input_resolution, output_resolution);
+  auto log_level = spdlog::level::level_enum::off;
+  for (auto item : kwargs) {
+    std::string key = py::cast<std::string>(item.first);
+    if (key == "log_level")  {
+      log_level = py::cast<spdlog::level::level_enum>(item.second);
+      break;
+    }
+  }
+
+  sirius::utils::LoggerManager::Instance().SetLogLevel(log_level);
+    
+  for (auto item : kwargs) {
+    std::string key = py::cast<std::string>(item.first);
+    if (key == "output_resolution") {
+      output_resolution = py::cast<int>(item.second);
+      zoom_ratio = sirius::ZoomRatio::Create(input_resolution, output_resolution);
+    }    
+    else if (key == "filter_image") {
+      py::buffer filter_buf = py::cast<py::buffer>(item.second);
+      py::buffer_info filter_info = filter_buf.request();
+      if (filter_info.ndim != 2)
+	throw std::runtime_error("Incompatible buffer dimension!");
+      auto img = sirius::Image(sirius::Size(filter_info.shape[0],  filter_info.shape[1]),
+			       std::vector<double>(static_cast<double*>(filter_info.ptr),
+						   static_cast<double*>(filter_info.ptr) + filter_info.shape[0] * filter_info.shape[1]));
+      filter = sirius::Filter::Create(img, zoom_ratio);
+    }
+    else if (key == "zoom_strategy")
+      zoom_strategy = py::cast<sirius::FrequencyZoomStrategies>(item.second);
+    else if (key == "image_decomposition")
+      image_decomposition = py::cast<sirius::ImageDecompositionPolicies>(item.second);
+    else if (key == "image_padding")
+      image_padding = py::cast<sirius::Padding>(item.second);
+  }
+
+  if (kwargs.contains("filter_image") && !kwargs.contains("zoom_strategy"))
+    zoom_strategy = sirius::FrequencyZoomStrategies::kPeriodization;
+
+  py::buffer_info input_array_info = input_array.request();
+  if (input_array_info.format != py::format_descriptor<double>::format())
+    throw std::runtime_error("Incompatible format: expected a double array!");
+  
+  if (input_array_info.ndim != 2)
+    throw std::runtime_error("Incompatible buffer dimension!");
+  
+  auto input_size = sirius::Size(input_array_info.shape[0],  input_array_info.shape[1]);
+  auto input_image = sirius::Image(input_size, std::vector<double>(static_cast<double*>(input_array_info.ptr),
+								   static_cast<double*>(input_array_info.ptr) + input_size.row * input_size.col));
+  
+  sirius::IFrequencyResampler::UPtr freq_resampler = sirius::FrequencyResamplerFactory::Create(image_decomposition, zoom_strategy);
+  auto output_image = freq_resampler->Compute(zoom_ratio, input_image, image_padding, filter);
+  auto output_buffer_size = output_image.size.row * output_image.size.col;
+  return py::array_t<double>(std::vector<ptrdiff_t>{output_image.size.row, output_image.size.col}, &output_image.data[0]);
+}
+
+PYBIND11_MODULE(siriuspy, m) {
+  using namespace sirius;
+ 
+ py::enum_<spdlog::level::level_enum>(m, "spdlog")
+   .value("trace", spdlog::level::trace)
+   .value("debug", spdlog::level::debug)
+   .value("info", spdlog::level::info)
+   .value("warn", spdlog::level::warn)
+   .value("err", spdlog::level::err)
+   .value("critical", spdlog::level::critical)
+   .value("off", spdlog::level::off)
+   .export_values();
+   
+  py::enum_<sirius::ImageDecompositionPolicies>(m, "ImageDecompositionPolicies")
+    .value("kRegular", sirius::ImageDecompositionPolicies::kRegular)
+    .value("kPeriodicSmooth", sirius::ImageDecompositionPolicies::kPeriodicSmooth)
+    .export_values();
+  
+  py::enum_<sirius::FrequencyZoomStrategies>(m, "FrequencyZoomStrategies")
+    .value("kZeroPadding", sirius::FrequencyZoomStrategies::kZeroPadding)
+    .value("kPeriodization", sirius::FrequencyZoomStrategies::kPeriodization)
+    .export_values();
+
+  py::class_<ZoomRatio>(m, "ZoomRatio")
+    .def_static("Create",     py::overload_cast<int,int>(&ZoomRatio::Create))
+    .def("ratio",                                 &ZoomRatio::ratio)
+    .def("IsRealZoom",                            &ZoomRatio::IsRealZoom)
+    .def("output_resolution",                     &ZoomRatio::output_resolution)
+    .def("input_resolution",                      &ZoomRatio::input_resolution)
+    ;
+  py::class_<Padding>(m, "Padding")
+    .def(py::init<int,int,int,int,PaddingType>())
+    .def("IsEmpty", &Padding::IsEmpty)
+    ;
+  py::enum_<sirius::PaddingType>(m, "PaddingType", py::arithmetic())
+    .value("kZeroPadding", sirius::PaddingType::kZeroPadding)
+    .value("kMirrorPadding", sirius::PaddingType::kMirrorPadding)
+    .export_values();
+  
+  m.def("resampler", &resampler, "Resample an image by a ratio in the frequency domain");  
+
+}

--- a/bindings/test.py
+++ b/bindings/test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import siriuspy
+import inspect
+def print_classes():
+    for name, obj in inspect.getmembers(siriuspy):
+        if inspect.isclass(obj):
+            print(obj) #, obj.__name__)
+
+#print_classes()
+import unittest
+import numpy
+from scipy import misc
+import matplotlib.pyplot as plt
+from PIL import Image
+from osgeo import gdal
+
+def gdal_load_image(filename, bindex=1):
+    dataset = gdal.Open(filename, gdal.GA_ReadOnly)
+    if not dataset:
+        raise ValueError('gdal.Open failed for', filename)
+    band = dataset.GetRasterBand(bindex)
+    nparray = band.ReadAsArray().astype(numpy.float)
+    return nparray
+
+
+npimage = numpy.zeros((256,256))
+for row in range(256):
+    for col in range(256):
+        npimage[row][col] = row * 10 + col + 1
+
+dirac_image = gdal_load_image("/home/rashad/projects/sirius/src/data/filters/dirac_filter.tif")
+sinc_image  = gdal_load_image("/home/rashad/projects/sirius/src/data/filters/sinc_zoom2_filter.tif")
+sinc_padding  = siriuspy.Padding(0, 0, 0, 0, siriuspy.PaddingType.kMirrorPadding)
+dirac_padding = siriuspy.Padding(0, 0, 0, 0, siriuspy.PaddingType.kMirrorPadding)
+
+class TestResampler(unittest.TestCase):
+
+    def test_log_level_critical(self):
+        zoomed_image = siriuspy.resampler(npimage, 6, log_level=siriuspy.spdlog.critical)
+        self.assertEqual(zoomed_image.shape, (1536,1536))
+
+    def test_log_level_debug(self):
+        zoomed_image = siriuspy.resampler(npimage, 6, log_level=siriuspy.spdlog.debug)
+        self.assertEqual(zoomed_image.shape, (1536,1536))
+        
+    def test_log_level_info(self):
+        zoomed_image = siriuspy.resampler(npimage, 6, log_level=siriuspy.spdlog.off)
+        self.assertEqual(zoomed_image.shape, (1536,1536))
+
+    def test_log_level_trace(self):
+        zoomed_image = siriuspy.resampler(npimage, 6, log_level=siriuspy.spdlog.off)
+        self.assertEqual(zoomed_image.shape, (1536,1536))
+
+
+    def test_resampler_with_all_non_default_values(self):
+        zoomed_image = siriuspy.resampler(npimage, 8,
+                                              output_resolution=4,
+                                              filter_image=dirac_image,
+                                              image_padding=sinc_padding,
+                                              image_decomposition=siriuspy.ImageDecompositionPolicies.kRegular,
+                                              zoom_strategy=siriuspy.FrequencyZoomStrategies.kZeroPadding)
+        self.assertEqual(zoomed_image.shape, (512,512))        
+
+    def test_resampler_with_all_options(self):
+        #print("zoom_strategy will not be changed\n")
+        zoomed_image = siriuspy.resampler(npimage, 2,
+                                              output_resolution=3,
+                                              filter_image=sinc_image,
+                                              image_padding=sinc_padding,
+                                              image_decomposition=siriuspy.ImageDecompositionPolicies.kPeriodicSmooth,
+                                              zoom_strategy=siriuspy.FrequencyZoomStrategies.kZeroPadding)
+        self.assertEqual(zoomed_image.shape, (128,128))
+
+    def test_resampler_with_different_image_decomposition_and_zoom_strategy(self):
+        zoomed_image = siriuspy.resampler(npimage, 8,
+                                              output_resolution=4,
+                                              filter_image=dirac_image,
+                                              image_decomposition=siriuspy.ImageDecompositionPolicies.kRegular,
+                                              zoom_strategy=siriuspy.FrequencyZoomStrategies.kPeriodization)
+        self.assertEqual(zoomed_image.shape, (512,512))
+
+    def test_resampler_with_filter_image_and_output_resolution(self):
+        #print("zoom_strategy will default to kPeriodization because of argument 'filter_image'\n")
+        zoomed_image = siriuspy.resampler(npimage, 2,
+                                              output_resolution=1,
+                                              filter_image=sinc_image)
+        self.assertEqual(zoomed_image.shape, (448,448))
+
+    def test_resampler_without_imagepadding_option(self):
+        zoomed_image = siriuspy.resampler(npimage, 2,
+                                              output_resolution=4,
+                                              filter_image=sinc_image, 
+                                              zoom_strategy=siriuspy.FrequencyZoomStrategies.kZeroPadding)
+        self.assertEqual(zoomed_image.shape, (96,96))
+
+    def test_resampler_with_only_required_options(self):
+        zoomed_image = siriuspy.resampler(npimage, 2)
+        self.assertEqual(zoomed_image.shape, (512,512))
+
+if __name__ == '__main__':
+    #unittest.main()
+    help(siriuspy.resampler)


### PR DESCRIPTION
*  new cmake option ENABLE_BINDINGS added (default is OFF) to build python bindings
* PYBIND11 is required to build siriuspy (pip package coming later)
* siriuspy expose a function called resampler which a wrapper method using SIRIUS API
* returns and accepts only numpy.
* only runtime dependency is libsirius library
* allows to control logging via log_level
* TODO detailed documentation 
